### PR TITLE
Implement cross_matrix() and assemble_matrix()

### DIFF
--- a/python_code/3d/assemble_matrix.py
+++ b/python_code/3d/assemble_matrix.py
@@ -12,6 +12,9 @@ def assemble_matrix(nxt_f,
     """
     Assemble 16 sub-matrices.
 
+    A sub-matrix `MVNs_ij` corresponds to 
+    `target_wing = i` and `source_wing = j`.
+
     The sub-matrices along the diagonal (coordinates [i, i])
     are constructed as below:
         `MVNs_11: ndarray[nxt_f, nxt_f] = MVNs_f[nxt_f, nxt_f, 0]`

--- a/python_code/3d/assemble_matrix.py
+++ b/python_code/3d/assemble_matrix.py
@@ -1,0 +1,60 @@
+import numpy as np
+
+def assemble_matrix(nxt_f,
+                    nxt_r,
+                    MVNs_f,
+                    MVNs_r,
+                    MVNs_12, MVNs_13, MVNs_14,
+                    MVNs_21, MVNs_23, MVNs_24,
+                    MVNs_31, MVNs_32, MVNs_34,
+                    MVNs_41, MVNs_42, MVNs_43
+):
+    """
+    Assemble 16 sub-matrices.
+
+    The sub-matrices along the diagonal (coordinates [i, i])
+    are constructed as below:
+        `MVNs_11: ndarray[nxt_f, nxt_f] = MVNs_f[nxt_f, nxt_f, 0]`
+        `MVNs_22: ndarray[nxt_f, nxt_f] = MVNs_f[nxt_f, nxt_f, 1]`
+        `MVNs_33: ndarray[nxt_r, nxt_r] = MVNs_r[nxt_r, nxt_r, 0]`
+        `MVNs_44: ndarray[nxt_r, nxt_r] = MVNs_r[nxt_r, nxt_r, 1]`
+    
+    Parameters
+    ----------
+    `nxt_f, nxt_r`: ints
+        Size of the sub-matrices for front (f) and rear (r) wings
+    `MVNs_f`: ndarray[nxt_f, nxt_f, 2]
+        Self-influence sub-matrices for front wings
+    `MVNs_r`: ndarray[nxt_r, nxt_r, 2]
+        Self-influence sub-matrices for rear wings
+    `MVNs_12`: ndarray[nxt_f, nxt_f]
+
+    `MVNs_13`: ndarray[nxt_f, nxt_r]
+
+    `MVNs_14`: ndarray[nxt_f, nxt_r]
+
+    `MVNs_21`: ndarray[nxt_f, nxt_f]
+
+    `MVNs_23`: ndarray[nxt_f, nxt_r]
+
+    `MVNs_24`: ndarray[nxt_f, nxt_r]
+
+    `MVNs_31`: ndarray[nxt_r, nxt_f]
+
+    `MVNs_32`: ndarray[nxt_r, nxt_f]
+
+    `MVNs_34`: ndarray[nxt_r, nxt_r]
+
+    `MVNs_41`: ndarray[nxt_r, nxt_f]
+
+    `MVNs_42`: ndarray[nxt_r, nxt_f]
+
+    `MVNs_43`: ndarray[nxt_r, nxt_r]
+
+    
+    Returns
+    -------
+    `MVN`: ndarray[2 * (nxt_f + nxt_r), 2 * (nxt_f + nxt_r)]
+        Assembled matrix
+    """
+    pass

--- a/python_code/3d/assemble_matrix.py
+++ b/python_code/3d/assemble_matrix.py
@@ -57,4 +57,26 @@ def assemble_matrix(nxt_f,
     `MVN`: ndarray[2 * (nxt_f + nxt_r), 2 * (nxt_f + nxt_r)]
         Assembled matrix
     """
-    pass
+    MVN = np.zeros((2 * (nxt_f + nxt_r), 2 * (nxt_f + nxt_r)))
+
+    MVN[0:nxt_f,    0             :   nxt_f           ] = MVNs_f [0:nxt_f, 0:nxt_f, 0]
+    MVN[0:nxt_f,    nxt_f         : 2*nxt_f           ] = MVNs_12[0:nxt_f, 0:nxt_f ]
+    MVN[0:nxt_f,  2*nxt_f         :(2*nxt_f +   nxt_r)] = MVNs_13[0:nxt_f, 0:nxt_r ]
+    MVN[0:nxt_f, (2*nxt_f + nxt_r):(2*nxt_f + 2*nxt_r)] = MVNs_14[0:nxt_f, 0:nxt_r ]
+ 
+    MVN[nxt_f: 2*nxt_f,   0            :   nxt_f           ] = MVNs_21[0:nxt_f, 0:nxt_f ]
+    MVN[nxt_f: 2*nxt_f,   nxt_f        : 2*nxt_f           ] = MVNs_f [0:nxt_f, 0:nxt_f, 1]
+    MVN[nxt_f: 2*nxt_f, 2*nxt_f        :(2*nxt_f +   nxt_r)] = MVNs_23[0:nxt_f, 0:nxt_r ]
+    MVN[nxt_f: 2*nxt_f, 2*nxt_f + nxt_r:(2*nxt_f + 2*nxt_r)] = MVNs_24[0:nxt_f, 0:nxt_r ]
+ 
+    MVN[2*nxt_f:(2*nxt_f + nxt_r),   0            :   nxt_f           ] = MVNs_31[0:nxt_r, 0:nxt_f ]
+    MVN[2*nxt_f:(2*nxt_f + nxt_r),   nxt_f        : 2*nxt_f           ] = MVNs_32[0:nxt_r, 0:nxt_f ]
+    MVN[2*nxt_f:(2*nxt_f + nxt_r), 2*nxt_f        :(2*nxt_f +   nxt_r)] = MVNs_r [0:nxt_r, 0:nxt_r, 0]
+    MVN[2*nxt_f:(2*nxt_f + nxt_r), 2*nxt_f + nxt_r:(2*nxt_f + 2*nxt_r)] = MVNs_34[0:nxt_r, 0:nxt_r ]
+ 
+    MVN[(2*nxt_f + nxt_r):(2*nxt_f + 2*nxt_r),    0             :   nxt_f           ] = MVNs_41[0:nxt_r, 0:nxt_f ]
+    MVN[(2*nxt_f + nxt_r):(2*nxt_f + 2*nxt_r),    nxt_f         : 2*nxt_f           ] = MVNs_42[0:nxt_r, 0:nxt_f ]
+    MVN[(2*nxt_f + nxt_r):(2*nxt_f + 2*nxt_r), 2*nxt_f          :(2*nxt_f +   nxt_r)] = MVNs_43[0:nxt_r, 0:nxt_r ]
+    MVN[(2*nxt_f + nxt_r):(2*nxt_f + 2*nxt_r), (2*nxt_f + nxt_r):(2*nxt_f + 2*nxt_r)] = MVNs_r [0:nxt_r, 0:nxt_r, 1]
+
+    return MVN

--- a/python_code/3d/cross_matrix.py
+++ b/python_code/3d/cross_matrix.py
@@ -1,9 +1,12 @@
 import numpy as np
+from VORTEXm import VORTEXm
 
 def cross_matrix(XC, NC, nxT, Xt, nxS):
     """
     Set up a sub-matrix for induced velocity on the target wing 
-    due to bound vortices on the source wing
+    due to bound vortices on the source wing. 
+    
+    This function is very similar to `lr_set_matrix()`.
 
     Parameters
     ----------
@@ -23,4 +26,51 @@ def cross_matrix(XC, NC, nxT, Xt, nxS):
     VN: ndarray[nxT, nxS]
         Sub-matrix for the nonpenetration condition 
     """
-    pass
+    # Set up a coefficient matrix for the nonpenetration condition 
+    # on the airfoil surface.
+    # Use collocation point vector XC[j, i] and the unit normal vector 
+    # NC[j, i] for the all collocation points.
+    VN = np.zeros((nxT, nxS))
+    s = np.shape(XC)
+
+    for i in range(nxS):
+        U = np.zeros(s[1])
+        V = np.zeros(s[1])
+        W = np.zeros(s[1])
+
+        dU, dV, dW = VORTEXm(XC[0, :], XC[1, :], XC[2, :], 
+                             Xt[0, 0, i], Xt[1, 0, i], Xt[2, 0, i], 
+                             Xt[0, 1, i], Xt[1, 1, i], Xt[2, 1, i], 
+                             1.0) 
+        U = U + dU
+        V = V + dV
+        W = W + dW
+
+        dU, dV, dW = VORTEXm(XC[0, :], XC[1, :], XC[2, :], 
+                             Xt[0, 1, i], Xt[1, 1, i], Xt[2, 1, i], 
+                             Xt[0, 2, i], Xt[1, 2, i], Xt[2, 2, i], 
+                             1.0)
+        U = U + dU
+        V = V + dV
+        W = W + dW
+
+        dU, dV, dW = VORTEXm(XC[0, :], XC[1, :], XC[2, :], 
+                             Xt[0, 2, i], Xt[1, 2, i], Xt[2, 2, i], 
+                             Xt[0, 3, i], Xt[1, 3, i], Xt[2, 3, i], 
+                             1.0)
+        U = U + dU
+        V = V + dV
+        W = W + dW
+
+        dU, dV, dW = VORTEXm(XC[0, :], XC[1, :], XC[2, :], 
+                             Xt[0, 3, i], Xt[1, 3, i], Xt[2, 3, i], 
+                             Xt[0, 0, i], Xt[1, 0, i], Xt[2, 0, i], 
+                             1.0)
+        U = U + dU
+        V = V + dV
+        W = W + dW
+        
+        # Normal velocity
+        VN[:, i] = (U * NC[0, :] + V * NC[1, :] + W * NC[2, :])
+
+    return VN

--- a/python_code/3d/cross_matrix.py
+++ b/python_code/3d/cross_matrix.py
@@ -1,0 +1,26 @@
+import numpy as np
+
+def cross_matrix(XC, NC, nxT, Xt, nxS):
+    """
+    Set up a sub-matrix for induced velocity on the target wing 
+    due to bound vortices on the source wing
+
+    Parameters
+    ----------
+    XC: ndarray[j, i]
+        Coordinates of the total collocation points on the target wing
+    NC: ndarray[j, i]
+        Unit normal at the total collocation points on the target wing
+    nxT: int
+        Number of total elements on the target wing
+    Xt: ndarray[j, n, i]
+        Coordinates of the total elements on the source wing
+    nxS: int
+        Number of total elements on the source wing
+
+    Returns
+    -------
+    VN: ndarray[nxT, nxS]
+        Sub-matrix for the nonpenetration condition 
+    """
+    pass

--- a/python_code/3d/lr_set_matrix.py
+++ b/python_code/3d/lr_set_matrix.py
@@ -24,54 +24,60 @@ def lr_set_matrix(iwing, Xt, nXt, XC, NC):
     VN: ndarray[nXt, nXt]
         Matrix for the nonpenetration condition
     """
+    # Create copies to avoid mutating the original arrays
+    # in the case of left wing (iwing == 1)
+    Xt__ = Xt.copy()
+    XC__ = XC.copy()
+    NC__ = NC.copy()
+
     # The left wing geometry is obtained by reversing the sign of the 
     # y-coordinate of the right wing
     if iwing == 1:
-        Xt[1, :, :] = -Xt[1, :, :]
-        XC[1, :] = -XC[1, :]
-        NC[1, :] = -NC[1, :]
+        Xt__[1, :, :] = -Xt__[1, :, :]
+        XC__[1, :] = -XC__[1, :]
+        NC__[1, :] = -NC__[1, :]
 
     VN = np.zeros((nXt, nXt))
-    s = np.shape(XC)
+    s = np.shape(XC__)
     
     for i in range(nXt):
         U = np.zeros((1, s[1]))
         V = np.zeros((1, s[1]))
         W = np.zeros((1, s[1]))
 
-        dU, dV, dW = VORTEXm(XC[0, :], XC[1, :], XC[2, :], 
-                             Xt[0, 0, i], Xt[1, 0, i], Xt[2, 0, i], 
-                             Xt[0, 1, i], Xt[1, 1, i], Xt[2, 1, i], 
+        dU, dV, dW = VORTEXm(XC__[0, :], XC__[1, :], XC__[2, :], 
+                             Xt__[0, 0, i], Xt__[1, 0, i], Xt__[2, 0, i], 
+                             Xt__[0, 1, i], Xt__[1, 1, i], Xt__[2, 1, i], 
                              1.0)
         U = U + dU
         V = V + dV
         W = W + dW
 
-        dU, dV, dW = VORTEXm(XC[0, :], XC[1, :], XC[2, :], 
-                             Xt[0, 1, i], Xt[1, 1, i], Xt[2, 1, i], 
-                             Xt[0, 2, i], Xt[1, 2, i], Xt[2, 2, i], 
+        dU, dV, dW = VORTEXm(XC__[0, :], XC__[1, :], XC__[2, :], 
+                             Xt__[0, 1, i], Xt__[1, 1, i], Xt__[2, 1, i], 
+                             Xt__[0, 2, i], Xt__[1, 2, i], Xt__[2, 2, i], 
                              1.0)
         U = U + dU
         V = V + dV
         W = W + dW
 
-        dU, dV, dW = VORTEXm(XC[0, :], XC[1, :], XC[2, :], 
-                             Xt[0, 2, i], Xt[1, 2, i], Xt[2, 2, i], 
-                             Xt[0, 3, i], Xt[1, 3, i], Xt[2, 3, i], 
+        dU, dV, dW = VORTEXm(XC__[0, :], XC__[1, :], XC__[2, :], 
+                             Xt__[0, 2, i], Xt__[1, 2, i], Xt__[2, 2, i], 
+                             Xt__[0, 3, i], Xt__[1, 3, i], Xt__[2, 3, i], 
                              1.0)
         U = U + dU
         V = V + dV
         W = W + dW
 
-        dU, dV, dW = VORTEXm(XC[0, :], XC[1, :], XC[2, :], 
-                             Xt[0, 3, i], Xt[1, 3, i], Xt[2, 3, i], 
-                             Xt[0, 0, i], Xt[1, 0, i], Xt[2, 0, i], 
+        dU, dV, dW = VORTEXm(XC__[0, :], XC__[1, :], XC__[2, :], 
+                             Xt__[0, 3, i], Xt__[1, 3, i], Xt__[2, 3, i], 
+                             Xt__[0, 0, i], Xt__[1, 0, i], Xt__[2, 0, i], 
                              1.0)
         U = U + dU
         V = V + dV
         W = W + dW
 
         # Normal velocity
-        VN[:, i] = (U * NC[0, :] + V * NC[1, :] + W * NC[2, :])
+        VN[:, i] = (U * NC__[0, :] + V * NC__[1, :] + W * NC__[2, :])
 
     return VN

--- a/python_code/3d/tombo.py
+++ b/python_code/3d/tombo.py
@@ -187,8 +187,6 @@ def tombo():
                              MVNs_21, MVNs_23, MVNs_24,
                              MVNs_31, MVNs_32, MVNs_34,
                              MVNs_41, MVNs_42, MVNs_43)
-        
-        dummy = 0
 
 
 def check_input():

--- a/python_code/3d/tombo.py
+++ b/python_code/3d/tombo.py
@@ -7,6 +7,8 @@ from wing_m import wing_m
 from lr_mass_L2GT import lr_mass_L2GT
 from lrs_wing_NVs import lrs_wing_NVs
 from n_vel_T_by_W import n_vel_T_by_W
+from cross_matrix import cross_matrix
+from assemble_matrix import assemble_matrix
 
 def tombo():
     # SETUP
@@ -152,6 +154,39 @@ def tombo():
             # Rear wing  
             Vncw_r[i,:] = n_vel_T_by_W(g.istep, nxt_r, XC_r[:,:,i], NC_r[:,:,i], 
                                        Xw_f, GAMw_f, nxw_f, Xw_r, GAMw_r, nxw_r) 
+
+        # Calculation of the time-dependent sub-matrices MVNs_ij (i~=j)
+        # target wing=1, source wing=2
+        MVNs_12 = cross_matrix(XC_f[:,:,0], NC_f[:,:,0], nxt_f, Xt_f[:,:,:,1], nxt_f)
+        # target wing=1, source wing=3
+        MVNs_13 = cross_matrix(XC_f[:,:,0], NC_f[:,:,0], nxt_f, Xt_r[:,:,:,0], nxt_r) 
+        # target wing=1, source wing=4
+        MVNs_14 = cross_matrix(XC_f[:,:,0], NC_f[:,:,0], nxt_f, Xt_r[:,:,:,1], nxt_r) 
+        # target wing=1, source wing=2
+        MVNs_21 = cross_matrix(XC_f[:,:,1], NC_f[:,:,1], nxt_f, Xt_f[:,:,:,0], nxt_f)
+        # target wing=1, source wing=3
+        MVNs_23 = cross_matrix(XC_f[:,:,1], NC_f[:,:,1], nxt_f, Xt_r[:,:,:,0], nxt_r) 
+        # target wing=1, source wing=4
+        MVNs_24 = cross_matrix(XC_f[:,:,1], NC_f[:,:,1], nxt_f, Xt_r[:,:,:,1], nxt_r)     
+        # target wing=1, source wing=2
+        MVNs_31 = cross_matrix(XC_r[:,:,0], NC_r[:,:,0], nxt_r, Xt_f[:,:,:,0], nxt_f)
+        # target wing=1, source wing=3
+        MVNs_32 = cross_matrix(XC_r[:,:,0], NC_r[:,:,0], nxt_r, Xt_f[:,:,:,1], nxt_f) 
+        # target wing=1, source wing=4
+        MVNs_34 = cross_matrix(XC_r[:,:,0], NC_r[:,:,0], nxt_r, Xt_r[:,:,:,1], nxt_r) 
+        # target wing=1, source wing=2
+        MVNs_41 = cross_matrix(XC_r[:,:,1], NC_r[:,:,1], nxt_r, Xt_f[:,:,:,0], nxt_f)
+        # target wing=1, source wing=3
+        MVNs_42 = cross_matrix(XC_r[:,:,1], NC_r[:,:,1], nxt_r, Xt_f[:,:,:,1], nxt_f) 
+        # target wing=1, source wing=4
+        MVNs_43 = cross_matrix(XC_r[:,:,1], NC_r[:,:,1], nxt_r, Xt_r[:,:,:,0], nxt_r) 
+    
+        # Assemble the total matrix using MVNs_f[:,:,1], MVNs_r[:,:,1], MVNs_ij[:,:]
+        MVN= assemble_matrix(nxt_f, nxt_r, MVNs_f, MVNs_r,
+                             MVNs_12, MVNs_13, MVNs_14,
+                             MVNs_21, MVNs_23, MVNs_24,
+                             MVNs_31, MVNs_32, MVNs_34,
+                             MVNs_41, MVNs_42, MVNs_43)
 
 
 def check_input():

--- a/python_code/3d/tombo.py
+++ b/python_code/3d/tombo.py
@@ -109,7 +109,7 @@ def tombo():
     # ----------
     for w in range(g.nwing):
         MVNs_f[:, :, w] = lr_set_matrix(w, xt_f, nxt_f, xC_f, nC_f)
-        MVNs_r[:, :, w] = lr_set_matrix(w, xt_f, nxt_f, xC_f, nC_f)
+        MVNs_r[:, :, w] = lr_set_matrix(w, xt_r, nxt_r, xC_r, nC_r)
 
     for g.istep in range(g.nstep):
         t = g.istep * g.dt
@@ -187,6 +187,8 @@ def tombo():
                              MVNs_21, MVNs_23, MVNs_24,
                              MVNs_31, MVNs_32, MVNs_34,
                              MVNs_41, MVNs_42, MVNs_43)
+        
+        dummy = 0
 
 
 def check_input():


### PR DESCRIPTION
This PR implements the functions `cross_matrix()` and `assemble_matrix()`.

It also adds those function calls to `tombo()`.

Notably, this PR also fixes a subtle bug that I found during testing in `lr_set_matrix()` caused by ndarrays being passed by reference. I have tested the functions after the bug fix and verified that the output matches the Matlab code.