### PR TITLE
Implement s_impulse_WT()

### DIFF
--- a/python_code/3d/s_impulse_WT.py
+++ b/python_code/3d/s_impulse_WT.py
@@ -107,3 +107,20 @@ def aimpulse(Xa, n1, n2, gama, beta, phi, theta, a):
         Angular impulse vector
     """
     pass
+
+def slimpulse_tr(X, gama, beta, phi, theta, a):
+    """
+    Calculate linear impulses due to the triangular bound or wake 
+    vortex elements in the wing-translating system
+    """
+    pass
+
+def saimpulse_tr(X, n, gama, beta, phi, theta, a):
+    """
+    Calculate moment of inertia for the triangular elements in 
+    the wing-translating system
+    """
+
+def triangle(X):
+    """Geometry of a triangle element"""
+    pass

--- a/python_code/3d/s_impulse_WT.py
+++ b/python_code/3d/s_impulse_WT.py
@@ -113,7 +113,7 @@ def limpulse(Xa, gama, beta, phi, theta, a):
     n1, limp1 = slimpulse_tr(X, gama, beta, phi, theta, a)
 
     # For triangle 0 2 3
-    X = np.zeros(3, 3, s[2])
+    X = np.zeros((3, 3, s[2]))
     tindex = [0, 2, 3]
     X = Xa[:, tindex, :]
     n2, limp2 = slimpulse_tr(X, gama, beta, phi, theta, a)
@@ -144,12 +144,12 @@ def aimpulse(Xa, n1, n2, gama, beta, phi, theta, a):
     s = np.shape(Xa)
 
     # For Triangle 0 1 2
-    X = np.zeros(3, 3, s[2])
+    X = np.zeros((3, 3, s[2]))
     X = Xa[:, 0:3, :]
     aimp1 = saimpulse_tr(X, n1, gama, beta, phi, theta, a)
 
     # For triangle 0 2 3
-    X = np.zeros(3, 3, s[2])
+    X = np.zeros((3, 3, s[2]))
     tindex = [0, 2, 3]
     X = Xa[:, tindex,:]
     aimp2 = saimpulse_tr(X, n2, gama, beta, phi, theta, a)

--- a/python_code/3d/s_impulse_WT.py
+++ b/python_code/3d/s_impulse_WT.py
@@ -95,7 +95,31 @@ def limpulse(Xa, gama, beta, phi, theta, a):
     limp: ndarray
         Linear impulse vector
     """
-    pass
+    # Divide Xa into 2 triangulr elements
+    # Rectangular element node numbering (%x-horizontal; y-vertical)
+    #  2   3
+    # 
+    #  1   4
+    # Divide into 2 triangle elements: 123 & 134
+    #  2   3        3
+    #         &
+    #  1        1   4
+    s = np.shape(Xa)
+    # For Triangle 1 2 3
+    X = np.zeros((3, 3, s[2]))
+    X = Xa[:, 0:3, :]
+    n1, limp1 = slimpulse_tr(X, gama, beta, phi, theta, a)
+
+    # For triangle 1 3 4
+    X = np.zeros(3, 3, s[2])
+    tindex = [1, 3, 4]
+    X = Xa[:, tindex, :]
+    n2, limp2 = slimpulse_tr(X, gama, beta, phi, theta, a)
+
+    # Add linear impulses from the two triangles
+    limp = limp1 + limp2
+
+    return limp
 
 def aimpulse(Xa, n1, n2, gama, beta, phi, theta, a):
     """

--- a/python_code/3d/s_impulse_WT.py
+++ b/python_code/3d/s_impulse_WT.py
@@ -197,6 +197,32 @@ def saimpulse_tr(X, n, gama, beta, phi, theta, a):
     Calculate moment of inertia for the triangular elements in 
     the wing-translating system
     """
+    h, lR, lL, S, xi, eta, xH = triangle(X)
+
+    A = [a, 0, 0]
+
+    s = np.shape(X)
+    Int      = np.zeros((3, s[2]))
+    IN       = np.zeros((3, s[2]))
+    impulseA = np.zeros((3, s[2]))
+    aimp = np.zeros(3)
+
+    for j in range(3):
+        Int[j,:] = (S * (A[j] + xH[j,:]) 
+                    + (1/6) * h * (lR+lL) * (xi[j,:] * (lR-lL) + eta[j,:] *h))
+
+    # Cross product of Int and n
+    IN[0,:]= Int[1,:] * n[2,:] - Int[2,:] * n[1,:]
+    IN[1,:]= Int[2,:] * n[0,:] - Int[0,:] * n[2,:]
+    IN[2,:]= Int[0,:] * n[1,:] - Int[1,:] * n[0,:]
+
+    for j in range(3):
+        impulseA[j,:] = -gama * IN[j,:]
+    
+    for j in range(3):
+        aimp[j] = np.sum(impulseA[j,:])
+    
+    return aimp
 
 def triangle(X):
     """Geometry of a triangle element"""

--- a/python_code/3d/s_impulse_WT.py
+++ b/python_code/3d/s_impulse_WT.py
@@ -121,7 +121,7 @@ def limpulse(Xa, gama, beta, phi, theta, a):
     # Add linear impulses from the two triangles
     limp = limp1 + limp2
 
-    return limp
+    return n1, n2, limp
 
 def aimpulse(Xa, n1, n2, gama, beta, phi, theta, a):
     """

--- a/python_code/3d/s_impulse_WT.py
+++ b/python_code/3d/s_impulse_WT.py
@@ -105,6 +105,7 @@ def limpulse(Xa, gama, beta, phi, theta, a):
     #         &
     #  1        1   4
     s = np.shape(Xa)
+
     # For Triangle 1 2 3
     X = np.zeros((3, 3, s[2]))
     X = Xa[:, 0:3, :]
@@ -130,7 +131,32 @@ def aimpulse(Xa, n1, n2, gama, beta, phi, theta, a):
     aimp: ndarray
         Angular impulse vector
     """
-    pass
+    # Divide Xa into 2 triangulr elements
+    # Rectangular element node numbering (%x-horizontal; y-vertical)
+    #  2   3
+    # 
+    #  1   4
+    # Divide into 2 triangle elements: 123 & 134
+    #  2   3        3
+    #         &
+    #  1        1   4
+    s = np.shape(Xa)
+
+    # For Triangle 1 2 3
+    X = np.zeros(3, 3, s[2])
+    X = Xa[:, 0:3, :]
+    aimp1 = saimpulse_tr(X, n1, gama, beta, phi, theta, a)
+
+    # For triangle 1 3 4
+    X = np.zeros(3, 3, s[2])
+    tindex = [1, 3, 4]
+    X = Xa[:, tindex,:]
+    aimp2 = saimpulse_tr(X, n2, gama, beta, phi, theta, a)
+
+    # Add angular impulses from the two triangles
+    aimp = aimp1 + aimp2
+    
+    return aimp
 
 def slimpulse_tr(X, gama, beta, phi, theta, a):
     """

--- a/python_code/3d/s_impulse_WT.py
+++ b/python_code/3d/s_impulse_WT.py
@@ -1,6 +1,7 @@
 import numpy as np
 from globals import g
 
+# TODO: Remove unused parameters beta, phi, theta
 def s_impulse_WT(istep, U, t, Xt, Xw, GAM, GAMAw, beta, phi, theta, a):
     """
     Calculate linear and angular impulses due to bound and wake 

--- a/python_code/3d/s_impulse_WT.py
+++ b/python_code/3d/s_impulse_WT.py
@@ -1,0 +1,45 @@
+import numpy as np
+from globals import g
+
+def s_impulse_WT(istep, U, t, Xt, Xw, GAM, GAMAw, beta, phi, theta, a):
+    """
+    Calculate linear and angular impulses due to bound and wake 
+    vortices in the body-translating system
+
+    Parameters
+    ----------
+    istep: int
+        Iteration step
+    U: ndarray
+        Ambient velocity
+    t: float
+        Time
+    Xt: ndarray[j, n, i, w]
+        Coordinates of the total elements on the wing
+    Xw: ndarray[j, n, i, w]
+        Coordinates of the wake vortices
+    GAM: ndarray[w, i]
+        Bound vortices
+    GAMAw: ndarray[w, i]
+        Wake vortices
+    beta: ndarray
+        Stroke plane angle
+    phi: ndarray
+        Wing rolling angle
+    theta: ndarray
+        Wing rotation angle
+    a: ndarray
+        Rotation axis offset
+
+    Returns
+    -------
+    limpa: ndarray[j, w]
+        Linear impulse from bound vortices
+    aimpa: ndarray[j, w]
+        Angular impulse from bound vortices
+    limpw: ndarray[j, w]
+        Linear impulse from wake vortices
+    aimpw: ndarray[j, w]
+        Angular impulse from wake vortices
+    """
+    pass

--- a/python_code/3d/s_impulse_WT.py
+++ b/python_code/3d/s_impulse_WT.py
@@ -163,7 +163,34 @@ def slimpulse_tr(X, gama, beta, phi, theta, a):
     Calculate linear impulses due to the triangular bound or wake 
     vortex elements in the wing-translating system
     """
-    pass
+    # Initialization
+    s = np.shape(X)
+    x1   = np.zeros((3,s[2]))
+    x2   = np.zeros((3,s[2]))
+    x1x2 = np.zeros((3, s[2]))
+    n    = np.zeros((3,s[2]))
+    limp = np.zeros(3)
+
+    # Linear impulse
+    for j in range(3):
+        x1[j,:] = X[j,2,:] - X[j,0,:]
+        x2[j,:] = X[j,1,:] - X[j,0,:]
+    # Cross product of x1 and x2
+    x1x2[0,:] = x1[1,:] * x2[2,:] - x1[2,:] * x2[1,:]
+    x1x2[1,:] = x1[2,:] * x2[0,:] - x1[0,:] * x2[2,:]
+    x1x2[2,:] = x1[0,:] * x2[1,:] - x1[1,:] * x2[0,:]
+    # Add contributions from all elements
+    limp[0] = -0.5 * np.dot(x1x2[0,:], gama)
+    limp[1] = -0.5 * np.dot(x1x2[1,:], gama)
+    limp[2] = -0.5 * np.dot(x1x2[2,:], gama)
+
+    # Unit normal
+    nx1x2 = np.sqrt(x1x2[0,:]**2 + x1x2[1,:]**2 + x1x2[2,:]**2)
+    
+    for j in range(3):
+        n[j,:] = x1x2[j,:] / nx1x2
+
+    return n, limp
 
 def saimpulse_tr(X, n, gama, beta, phi, theta, a):
     """

--- a/python_code/3d/s_impulse_WT.py
+++ b/python_code/3d/s_impulse_WT.py
@@ -84,8 +84,26 @@ def s_impulse_WT(istep, U, t, Xt, Xw, GAM, GAMAw, beta, phi, theta, a):
     return limpa, aimpa, limpw, aimpw
 
 
-def limpulse():
+def limpulse(Xa, gama, beta, phi, theta, a):
+    """
+    Calculate linear impulses in the wing-translating system
+
+    Returns
+    -------
+    n1, n2: ndarray[j, i]
+        Two unit normal vectors for two triangles
+    limp: ndarray
+        Linear impulse vector
+    """
     pass
 
-def aimpulse():
+def aimpulse(Xa, n1, n2, gama, beta, phi, theta, a):
+    """
+    Calculate moment of inertia in the wing-translating system
+
+    Returns
+    -------
+    aimp: ndarray
+        Angular impulse vector
+    """
     pass

--- a/python_code/3d/s_impulse_WT.py
+++ b/python_code/3d/s_impulse_WT.py
@@ -42,4 +42,50 @@ def s_impulse_WT(istep, U, t, Xt, Xw, GAM, GAMAw, beta, phi, theta, a):
     aimpw: ndarray[j, w]
         Angular impulse from wake vortices
     """
+    limpa = np.zeros((3, g.nwing))
+    aimpa = np.zeros((3, g.nwing))
+    limpw = np.zeros((3, g.nwing))
+    aimpw = np.zeros((3, g.nwing))
+
+    # From global to translating inertia
+    Xt_T = np.zeros_like(Xt)
+    Xw_T = np.zeros_like(Xw)
+
+    for i in range(g.nwing):
+        Xt_T[0,:,:,i] = U[0] * t + Xt[0,:,:,i]
+        Xt_T[1,:,:,i] = U[1] * t + Xt[1,:,:,i]
+        Xt_T[2,:,:,i] = U[2] * t + Xt[2,:,:,i]
+
+        if istep > 0:
+            Xw_T[0,:,:,i] = U[0] * t + Xw[0,:,:,i]
+            Xw_T[1,:,:,i] = U[1] * t + Xw[1,:,:,i]
+            Xw_T[2,:,:,i] = U[2] * t + Xw[2,:,:,i]
+
+    for i in range(g.nwing):
+        # Bound vortices
+        # Linear impulse
+        n1, n2, limp = limpulse(Xt_T[:,:,:,i], GAM[i,:], beta[i], phi[i], theta[i], a[i])
+        # n1[j,nXt], n2[j,nXt] = unit normal for 2 triangular iXt_th element
+        limpa[:,i] = limp
+        # Angular impulse
+        aimp = aimpulse(Xt_T[:,:,:,i], n1, n2, GAM[i,:], beta[i], phi[i], theta[i], a[i])
+        aimpa[:,i] = aimp
+
+        if istep > 0:
+            # Wake vortices
+            # Linear impulse
+            n1, n2, limp = limpulse(Xw_T[:,:,:,i], GAMAw[i,:], beta[i], phi[i], theta[i], a[i])
+            limpw[:,i] = limp       # limpw(:,istep) + limp
+
+            # Angular impulse
+            aimp = aimpulse(Xw_T[:,:,:,i], n1, n2, GAMAw[i,:], beta[i], phi[i], theta[i], a[i])
+            aimpw[:,i] = aimp       # aimpw(:,istep) + aimp
+    
+    return limpa, aimpa, limpw, aimpw
+
+
+def limpulse():
+    pass
+
+def aimpulse():
     pass

--- a/python_code/3d/s_impulse_WT.py
+++ b/python_code/3d/s_impulse_WT.py
@@ -226,4 +226,44 @@ def saimpulse_tr(X, n, gama, beta, phi, theta, a):
 
 def triangle(X):
     """Geometry of a triangle element"""
-    pass
+    s = np.shape(X)
+    x21 = np.zeros((3, s[2]))
+    x23 = np.zeros((3, s[2]))
+
+    for j in range(3):
+        x21[j,:] = X[j,0,:] - X[j,1,:]
+        x23[j,:] = X[j,2,:] - X[j,1,:]
+
+    nx21 = np.sqrt(x21[0,:]**2 + x21[1,:]**2 + x21[2,:]**2)
+    nx23 = np.sqrt(x23[0,:]**2 + x23[1,:]**2 + x23[2,:]**2)     # Unused
+
+    l = nx21
+    xi = np.zeros((3, s[2]))
+    for j in range(3):
+        xi[j,:] = x21[j,:] / l
+    
+    lL = x23[0,:] * xi[0,:] + x23[1,:] * xi[1,:] + x23[2,:] * xi[2,:]
+    lR = l - lL
+
+    xj2 = np.zeros((3, s[2]))
+    xj3 = np.zeros((3, s[2]))
+    x2H = np.zeros((3, s[2]))
+    xH  = np.zeros((3, s[2]))
+    xH3 = np.zeros((3, s[2]))
+
+    for j in range(3):
+        xj2[j,:] = X[j,1,:]
+        xj3[j,:] = X[j,2,:]
+        x2H[j,:] = x21[j,:] * lL / l
+        xH [j,:] = xj2[j,:] + x2H[j,:]
+        xH3[j,:] = xj3[j,:] - xH[j,:]
+    
+    h = np.sqrt(xH3[0,:]**2 + xH3[1,:]**2 + xH3[2,:]**2)
+
+    eta = np.zeros((3, s[2]))
+    for j in range(3):
+        eta[j,:] = xH3[j,:] / h
+    
+    S = 0.5 * l * h
+
+    return h, lR, lL, S, xi, eta, xH

--- a/python_code/3d/s_impulse_WT.py
+++ b/python_code/3d/s_impulse_WT.py
@@ -95,25 +95,25 @@ def limpulse(Xa, gama, beta, phi, theta, a):
     limp: ndarray
         Linear impulse vector
     """
-    # Divide Xa into 2 triangulr elements
-    # Rectangular element node numbering (%x-horizontal; y-vertical)
-    #  2   3
+    # Divide Xa into 2 triangular elements
+    # Rectangular element node numbering (x-horizontal; y-vertical)
+    #  1   2
     # 
-    #  1   4
-    # Divide into 2 triangle elements: 123 & 134
-    #  2   3        3
+    #  0   3
+    # Divide into 2 triangle elements: 012 & 023
+    #  1   2        2
     #         &
-    #  1        1   4
+    #  0        0   3
     s = np.shape(Xa)
 
-    # For Triangle 1 2 3
+    # For Triangle 0 1 2
     X = np.zeros((3, 3, s[2]))
     X = Xa[:, 0:3, :]
     n1, limp1 = slimpulse_tr(X, gama, beta, phi, theta, a)
 
-    # For triangle 1 3 4
+    # For triangle 0 2 3
     X = np.zeros(3, 3, s[2])
-    tindex = [1, 3, 4]
+    tindex = [0, 2, 3]
     X = Xa[:, tindex, :]
     n2, limp2 = slimpulse_tr(X, gama, beta, phi, theta, a)
 
@@ -131,25 +131,25 @@ def aimpulse(Xa, n1, n2, gama, beta, phi, theta, a):
     aimp: ndarray
         Angular impulse vector
     """
-    # Divide Xa into 2 triangulr elements
-    # Rectangular element node numbering (%x-horizontal; y-vertical)
-    #  2   3
+    # Divide Xa into 2 triangular elements
+    # Rectangular element node numbering (x-horizontal; y-vertical)
+    #  1   2
     # 
-    #  1   4
-    # Divide into 2 triangle elements: 123 & 134
-    #  2   3        3
+    #  0   3
+    # Divide into 2 triangle elements: 012 & 023
+    #  1   2        2
     #         &
-    #  1        1   4
+    #  0        0   3
     s = np.shape(Xa)
 
-    # For Triangle 1 2 3
+    # For Triangle 0 1 2
     X = np.zeros(3, 3, s[2])
     X = Xa[:, 0:3, :]
     aimp1 = saimpulse_tr(X, n1, gama, beta, phi, theta, a)
 
-    # For triangle 1 3 4
+    # For triangle 0 2 3
     X = np.zeros(3, 3, s[2])
-    tindex = [1, 3, 4]
+    tindex = [0, 2, 3]
     X = Xa[:, tindex,:]
     aimp2 = saimpulse_tr(X, n2, gama, beta, phi, theta, a)
 

--- a/python_code/3d/s_impulse_WT.py
+++ b/python_code/3d/s_impulse_WT.py
@@ -235,7 +235,7 @@ def triangle(X):
         x23[j,:] = X[j,2,:] - X[j,1,:]
 
     nx21 = np.sqrt(x21[0,:]**2 + x21[1,:]**2 + x21[2,:]**2)
-    nx23 = np.sqrt(x23[0,:]**2 + x23[1,:]**2 + x23[2,:]**2)     # Unused
+    # nx23 = np.sqrt(x23[0,:]**2 + x23[1,:]**2 + x23[2,:]**2)   # Unused, TODO: Ask why
 
     l = nx21
     xi = np.zeros((3, s[2]))

--- a/python_code/3d/tombo.py
+++ b/python_code/3d/tombo.py
@@ -12,7 +12,7 @@ from assemble_matrix import assemble_matrix
 from solution import solution
 # from plot_GAM import plot_GAM
 # from plot_WB import plot_WB
-# from s_impulse_WT import s_impulse_WT
+from s_impulse_WT import s_impulse_WT
 from divide_GAM import divide_GAM
 
 def tombo():
@@ -218,11 +218,30 @@ def tombo():
         # plot_WB(0, g.istep, g.nxb_f, nxw_f, Xb_f, Xw_f)     # Front wing
         # plot_WB(1, g.istep, g.nxb_r, nxw_r, Xb_r, Xw_r)     # Rear wing
 
-        # if g.nstep > 3:     # At least 4 steps needed to calculate forces and moments
+        if g.nstep > 3:     # At least 4 steps needed to calculate forces and moments
             # Calculate impulses in the body-translating system
             # Include all of the bound vortices and wake vortices
             # For istep=1, there are no wake vortices
-            # TODO
+            # Front wing
+            limpa, aimpa, limpw, aimpw = \
+                s_impulse_WT(g.istep, U, t, Xt_f, Xw_f, GAM_f, GAMw_f, 
+                             beta[0:2], phi[0:2], theta[0:2], a[0:2])
+            for j in range(3):
+                for w in range(g.nwing):
+                    limpa_f[j, g.istep, w] = limpa[j, w]
+                    aimpa_f[j, g.istep, w] = aimpa[j, w]
+                    limpw_f[j, g.istep, w] = limpw[j, w]
+                    aimpw_f[j, g.istep, w] = aimpw[j, w]
+            # Rear wing
+            limpa, aimpa, limpw, aimpw = \
+                s_impulse_WT(g.istep, U, t, Xt_r, Xw_r, GAM_r, GAMw_r,
+                             beta[2:4], phi[2:4], theta[2:4], a[2:4]) 
+            for j in range(3):
+                for w in range(3):
+                    limpa_r[j, g.istep, w] = limpa[j, w]
+                    aimpa_r[j, g.istep, w] = aimpa[j, w]
+                    limpw_r[j, g.istep, w] = limpw[j, w]
+                    aimpw_r[j, g.istep, w] = aimpw[j, w]  
 
         # Extract GAMAb (border & shed ) from GAM
         GAMAb_f = divide_GAM(GAM_f, g.nxb_f)


### PR DESCRIPTION
Resolves #21 

This PR implements the function `s_impulse_WT()` and the functions it depends on.

It also updates `tombo()` to call the function.

I have tested and verified that the output matches the Matlba code, but only the linear impulses. The angular impulses are not calculated for `istep == 0`, so it is very possible that there is a bug in that section. We can test and debug the angular impulse calculation later.