### PR TITLE
Implement tbshedB(), tbconvW(), add_wake()

### DIFF
--- a/python_code/3d/add_wake.py
+++ b/python_code/3d/add_wake.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+def add_wake(nXb, GAMAb, Xs, GAMAw, Xw):
+    """
+    Add shed vortices to wake vortices
+
+    Parameters
+    ----------
+    nXb: int
+        Number of border elements
+    GAMAb: ndarray[w, iXb]
+        Shed vortices (border vortices)
+    Xs: ndarray[j, n, iXb, w]
+        Location of shed vortices (after convection)
+    GAMAw: ndarray[w, iXw]
+        Wake vortices
+    Xw: ndarray[j, n, iXw, w]
+        Location of wake vortices (after convection)
+
+    Returns
+    -------
+    GANAw: ndarray[w, iXw]
+        Wake vortices for next step
+    nXw: int
+        Updated number of wake vortices for next step
+    Xw: ndarray[j, n, iXw, w]
+        Location of wake voritces for next step
+        (in wing-fixed system)
+    """
+    pass

--- a/python_code/3d/add_wake.py
+++ b/python_code/3d/add_wake.py
@@ -1,4 +1,5 @@
 import numpy as np
+from globals import g
 
 def add_wake(nXb, GAMAb, Xs, GAMAw, Xw):
     """
@@ -27,4 +28,11 @@ def add_wake(nXb, GAMAb, Xs, GAMAw, Xw):
         Location of wake voritces for next step
         (in wing-fixed system)
     """
-    pass
+    # Add the newly shed vortices to the wake vortices
+    GAMAw = [GAMAw, GAMAb]  # increment in each step
+    nXw = np.shape(GAMAw)[1]
+
+    # Add the location of the newly shed vortices to existing wake vortex locations
+    s = np.shape(Xw)
+    for i in range(g.nwing):
+        Xw[:3, :4, s[2]:nXw, i] = Xs[:3, :4, :nXb, i]

--- a/python_code/3d/tombo.py
+++ b/python_code/3d/tombo.py
@@ -19,6 +19,7 @@ from b_vel_B_by_T_matrix import b_vel_B_by_T_matrix
 from vel_B_by_T import vel_B_by_T
 from cross_vel_B_by_T import cross_vel_B_by_T
 from assemble_vel_B_by_T import assemble_vel_B_by_T
+from add_wake import add_wake
 
 def tombo():
     # SETUP
@@ -290,7 +291,22 @@ def tombo():
         # Convect wake vortices
         # if g.istep > 0:
         #     Xw_f = Xw_f + g.dt * (VWT_f + VWW_f)
-        #     Xw_r = Xw_r + g.dt * (VWT_f + VWW_f) 
+        #     Xw_r = Xw_r + g.dt * (VWT_f + VWW_f)
+
+        # Add shed vortices to wake vortex
+        if g.istep == 1:
+            # Front wings
+            GAMw_f = GAMAb_f
+            nxw_f = g.nxb_f
+            Xw_f = Xs_f
+            # Rear wings
+            GAMw_r = GAMAb_r
+            nxw_r = g.nxb_r
+            Xw_r = Xs_r
+        else:
+            # TODO: pre-allocate Xw_f, Xw_r
+            GAMw_f, nxw_f, Xw_f = add_wake(g.nxb_f, GAMAb_f, Xs_f, GAMw_f, Xw_f)
+            GAMw_r, nxw_r, Xw_r = add_wake(g.nxb_r, GAMAb_r, Xs_r, GAMw_r, Xw_r)
 
 
 def check_input():

--- a/python_code/3d/tombo.py
+++ b/python_code/3d/tombo.py
@@ -287,6 +287,11 @@ def tombo():
         Xs_f = Xb_f + g.dt * (VBT_f + VBW_f)
         Xs_r = Xb_r + g.dt * (VBT_r + VBT_r)
 
+        # Convect wake vortices
+        # if g.istep > 0:
+        #     Xw_f = Xw_f + g.dt * (VWT_f + VWW_f)
+        #     Xw_r = Xw_r + g.dt * (VWT_f + VWW_f) 
+
 
 def check_input():
     if g.b_r - g.b_f >= 0.5 * (g.c_r + g.c_f):

--- a/python_code/3d/tombo.py
+++ b/python_code/3d/tombo.py
@@ -280,6 +280,12 @@ def tombo():
         # Assemble the total border element velocity due to two wings
         VBT_f,VBT_r = assemble_vel_B_by_T(g.nxb_f, VBTs_f, VBTs_12, VBTs_13, VBTs_14, VBTs_21, VBTs_23, VBTs_24,
                                           g.nxb_r, VBTs_r, VBTs_31, VBTs_32, VBTs_34, VBTs_41, VBTs_42, VBTs_43)
+        
+        # TODO: Velocity calculations
+
+        # Shed border vortex elements
+        Xs_f = Xb_f + g.dt * (VBT_f + VBW_f)
+        Xs_r = Xb_r + g.dt * (VBT_r + VBT_r)
 
 
 def check_input():

--- a/python_code/3d/tombo.py
+++ b/python_code/3d/tombo.py
@@ -286,7 +286,7 @@ def tombo():
 
         # Shed border vortex elements
         Xs_f = Xb_f + g.dt * (VBT_f + VBW_f)
-        Xs_r = Xb_r + g.dt * (VBT_r + VBT_r)
+        Xs_r = Xb_r + g.dt * (VBT_r + VBW_r)
 
         # Convect wake vortices
         # if g.istep > 0:

--- a/python_code/3d/tombo.py
+++ b/python_code/3d/tombo.py
@@ -294,7 +294,7 @@ def tombo():
         #     Xw_r = Xw_r + g.dt * (VWT_f + VWW_f)
 
         # Add shed vortices to wake vortex
-        if g.istep == 1:
+        if g.istep == 0:
             # Front wings
             GAMw_f = GAMAb_f
             nxw_f = g.nxb_f


### PR DESCRIPTION
This PR implements the mentioned functions.

`tbshedB()` and `tbconvW()` are one liners, so they were just implemented in place in `tombo()`.

`add_wake()` is implemented, but importantly, `Xw_f` and `Xw_r` need to be pre-allocated for it to work. So it is non-functional at this point in time.

`tombo()` has been updated to call these functions. I tested what I could, but the general case where `istep > 0` has not been tested.