### PR TITLE
Implement vel_by()

### DIFF
--- a/python_code/3d/add_wake.py
+++ b/python_code/3d/add_wake.py
@@ -36,3 +36,5 @@ def add_wake(nXb, GAMAb, Xs, GAMAw, Xw):
     s = np.shape(Xw)
     for i in range(g.nwing):
         Xw[:3, :4, s[2]:nXw, i] = Xs[:3, :4, :nXb, i]
+
+    return GAMAw, nXw, Xw

--- a/python_code/3d/add_wake.py
+++ b/python_code/3d/add_wake.py
@@ -29,7 +29,7 @@ def add_wake(nXb, GAMAb, Xs, GAMAw, Xw):
         (in wing-fixed system)
     """
     # Add the newly shed vortices to the wake vortices
-    GAMAw = [GAMAw, GAMAb]  # increment in each step
+    GAMAw = np.hstack((GAMAw, GAMAb))   # build incrementally each step
     nXw = np.shape(GAMAw)[1]
 
     # Add the location of the newly shed vortices to existing wake vortex locations

--- a/python_code/3d/add_wake.py
+++ b/python_code/3d/add_wake.py
@@ -34,7 +34,6 @@ def add_wake(nXb, GAMAb, Xs, GAMAw, Xw):
 
     # Add the location of the newly shed vortices to existing wake vortex locations
     s = g.istep * nXb
-    for i in range(g.nwing):
-        Xw[:, :, s:nXw, i] = Xs[:, :, :nXb, i]
+    Xw[:, :, s:nXw, :g.nwing] = Xs[:, :, :nXb, :g.nwing]
 
     return GAMAw, nXw, Xw

--- a/python_code/3d/add_wake.py
+++ b/python_code/3d/add_wake.py
@@ -33,8 +33,8 @@ def add_wake(nXb, GAMAb, Xs, GAMAw, Xw):
     nXw = np.shape(GAMAw)[1]
 
     # Add the location of the newly shed vortices to existing wake vortex locations
-    s = np.shape(Xw)
+    s = g.istep * nXb
     for i in range(g.nwing):
-        Xw[:3, :4, s[2]:nXw, i] = Xs[:3, :4, :nXb, i]
+        Xw[:, :, s:nXw, i] = Xs[:, :, :nXb, i]
 
     return GAMAw, nXw, Xw

--- a/python_code/3d/globals.py
+++ b/python_code/3d/globals.py
@@ -20,7 +20,7 @@ class g:
 
     # Output files
 
-    folder: str = 'fig/'
+    folder: str = 'python_code/3d/fig/'
     """Path to output folder"""
     # fid = open(f"{folder}/output.txt", 'w')
     """Output file"""

--- a/python_code/3d/n_vel_T_by_W.py
+++ b/python_code/3d/n_vel_T_by_W.py
@@ -46,8 +46,8 @@ def n_vel_T_by_W(istep, nXt, XC, NC, Xw2_f, GAMAw2_f, nXw_f, Xw2_r, GAMAw2_r, nX
     # TODO: Lots of repetition, probably lots of parallelizable tasks, lots of opitmization opportunities
     # Contribution from forward wing wake
     GAMAw = GAMAw2_f[0, :]
-    GAMw = np.reshape(GAMAw, (1, 1 , nXw_f))
-    Xw = Xw2_f[:, :, :, 0]
+    GAMw = np.reshape(GAMAw, nXw_f)
+    Xw = Xw2_f[:, :, :nXw_f, 0]
     for i in range(nXt):
         x = XC[0, i]
         y = XC[1, i]
@@ -74,8 +74,8 @@ def n_vel_T_by_W(istep, nXt, XC, NC, Xw2_f, GAMAw2_f, nXw_f, Xw2_r, GAMAw2_r, nX
         Vncw[i] += u * NC[0, i] + v * NC[1, i] + w * NC[2, i]
     
     GAMAw = GAMAw2_f[1, :]
-    GAMw = np.reshape(GAMAw, (1, 1, nXw_f))
-    Xw = Xw2_f[:, :, :, 1]
+    GAMw = np.reshape(GAMAw, nXw_f)
+    Xw = Xw2_f[:, :, :nXw_f, 1]
     for i in range(nXt):
         x = XC[0, i]
         y = XC[1, i]
@@ -103,8 +103,8 @@ def n_vel_T_by_W(istep, nXt, XC, NC, Xw2_f, GAMAw2_f, nXw_f, Xw2_r, GAMAw2_r, nX
  
     # Contribution from rear wing wake
     GAMAw = GAMAw2_r[0, :]
-    GAMw = np.reshape(GAMAw, (1, 1, nXw_r))
-    Xw = Xw2_r[:, :, :, 0]
+    GAMw = np.reshape(GAMAw, nXw_r)
+    Xw = Xw2_r[:, :, :nXw_r, 0]
     for i in range(nXt):
         x = XC[0, i]
         y = XC[1, i]
@@ -131,8 +131,8 @@ def n_vel_T_by_W(istep, nXt, XC, NC, Xw2_f, GAMAw2_f, nXw_f, Xw2_r, GAMAw2_r, nX
         Vncw[i] += u * NC[0, i] + v * NC[1, i] + w * NC[2, i]
     
     GAMAw = GAMAw2_r[1, :]
-    GAMw = np.reshape(GAMAw, (1, 1, nXw_r))
-    Xw = Xw2_r[:, :, :, 1]
+    GAMw = np.reshape(GAMAw, nXw_r)
+    Xw = Xw2_r[:, :, :nXw_r, 1]
     for i in range(nXt):
         x = XC[0, i]
         y = XC[1, i]

--- a/python_code/3d/n_vel_T_by_W.py
+++ b/python_code/3d/n_vel_T_by_W.py
@@ -38,124 +38,58 @@ def n_vel_T_by_W(istep, nXt, XC, NC, Xw2_f, GAMAw2_f, nXw_f, Xw2_r, GAMAw2_r, nX
         Normal velocity components at the collocation points due to
         wake vortices
     """
+    def helper(Vncw, Xw, GAMw):
+        for i in range(nXt):
+            x = XC[0, i]
+            y = XC[1, i]
+            z = XC[2, i]
+            u, v, w = 0, 0, 0
+        
+            u1, v1, w1 = mVORTEX(x, y, z, Xw[0,0,:], Xw[1,0,:], Xw[2,0,:], Xw[0,1,:], Xw[1,1,:], Xw[2,1,:], GAMw)
+            u = u + u1
+            v = v + v1
+            w = w + w1
+            u2, v2, w2 = mVORTEX(x, y, z, Xw[0,1,:], Xw[1,1,:], Xw[2,1,:], Xw[0,2,:], Xw[1,2,:], Xw[2,2,:], GAMw)
+            u = u + u2
+            v = v + v2
+            w = w + w2
+            u3, v3, w3 = mVORTEX(x, y, z, Xw[0,2,:], Xw[1,2,:], Xw[2,2,:], Xw[0,3,:], Xw[1,3,:], Xw[2,3,:], GAMw)
+            u = u + u3
+            v = v + v3
+            w = w + w3
+            u4, v4, w4 = mVORTEX(x, y, z, Xw[0,3,:], Xw[1,3,:], Xw[2,3,:], Xw[0,0,:], Xw[1,0,:], Xw[2,0,:], GAMw)
+            u = u + u4
+            v = v + v4
+            w = w + w4
+        
+            Vncw[i] += u * NC[0, i] + v * NC[1, i] + w * NC[2, i]
+
+
     Vncw = np.zeros(nXt)
 
     if istep <= 0:
         return Vncw
     
-    # TODO: Lots of repetition, probably lots of parallelizable tasks, lots of opitmization opportunities
     # Contribution from forward wing wake
     GAMAw = GAMAw2_f[0, :]
     GAMw = np.reshape(GAMAw, nXw_f)
     Xw = Xw2_f[:, :, :nXw_f, 0]
-    for i in range(nXt):
-        x = XC[0, i]
-        y = XC[1, i]
-        z = XC[2, i]
-        u, v, w = 0, 0, 0
-    
-        u1, v1, w1 = mVORTEX(x, y, z, Xw[0,0,:], Xw[1,0,:], Xw[2,0,:], Xw[0,1,:], Xw[1,1,:], Xw[2,1,:], GAMw)
-        u = u + u1
-        v = v + v1
-        w = w + w1
-        u2, v2, w2 = mVORTEX(x, y, z, Xw[0,1,:], Xw[1,1,:], Xw[2,1,:], Xw[0,2,:], Xw[1,2,:], Xw[2,2,:], GAMw)
-        u = u + u2
-        v = v + v2
-        w = w + w2
-        u3, v3, w3 = mVORTEX(x, y, z, Xw[0,2,:], Xw[1,2,:], Xw[2,2,:], Xw[0,3,:], Xw[1,3,:], Xw[2,3,:], GAMw)
-        u = u + u3
-        v = v + v3
-        w = w + w3
-        u4, v4, w4 = mVORTEX(x, y, z, Xw[0,3,:], Xw[1,3,:], Xw[2,3,:], Xw[0,0,:], Xw[1,0,:], Xw[2,0,:], GAMw)
-        u = u + u4
-        v = v + v4
-        w = w + w4
-    
-        Vncw[i] += u * NC[0, i] + v * NC[1, i] + w * NC[2, i]
+    helper(Vncw, Xw, GAMw)
     
     GAMAw = GAMAw2_f[1, :]
     GAMw = np.reshape(GAMAw, nXw_f)
     Xw = Xw2_f[:, :, :nXw_f, 1]
-    for i in range(nXt):
-        x = XC[0, i]
-        y = XC[1, i]
-        z = XC[2, i]
-        u, v, w = 0, 0, 0
-    
-        u1, v1, w1 = mVORTEX(x, y, z, Xw[0,0,:], Xw[1,0,:], Xw[2,0,:], Xw[0,1,:], Xw[1,1,:], Xw[2,1,:], GAMw)
-        u = u + u1
-        v = v + v1
-        w = w + w1
-        u2, v2, w2 = mVORTEX(x, y, z, Xw[0,1,:], Xw[1,1,:], Xw[2,1,:], Xw[0,2,:], Xw[1,2,:], Xw[2,2,:], GAMw)
-        u = u + u2
-        v = v + v2
-        w = w + w2
-        u3, v3, w3 = mVORTEX(x, y, z, Xw[0,2,:], Xw[1,2,:], Xw[2,2,:], Xw[0,3,:], Xw[1,3,:], Xw[2,3,:], GAMw)
-        u = u + u3
-        v = v + v3
-        w = w + w3
-        u4, v4, w4 = mVORTEX(x, y, z, Xw[0,3,:], Xw[1,3,:], Xw[2,3,:], Xw[0,0,:], Xw[1,0,:], Xw[2,0,:], GAMw)
-        u = u + u4
-        v = v + v4
-        w = w + w4
-    
-        Vncw[i] += u * NC[0, i] + v * NC[1, i] + w * NC[2, i]    
+    helper(Vncw, Xw, GAMw)
  
     # Contribution from rear wing wake
     GAMAw = GAMAw2_r[0, :]
     GAMw = np.reshape(GAMAw, nXw_r)
     Xw = Xw2_r[:, :, :nXw_r, 0]
-    for i in range(nXt):
-        x = XC[0, i]
-        y = XC[1, i]
-        z = XC[2, i]
-        u, v, w = 0, 0, 0
-    
-        u1, v1, w1 = mVORTEX(x, y, z, Xw[0,0,:], Xw[1,0,:], Xw[2,0,:], Xw[0,1,:], Xw[1,1,:], Xw[2,1,:], GAMw)
-        u = u + u1
-        v = v + v1
-        w = w + w1
-        u2, v2, w2 = mVORTEX(x, y, z, Xw[0,1,:], Xw[1,1,:], Xw[2,1,:], Xw[0,2,:], Xw[1,2,:], Xw[2,2,:], GAMw)
-        u = u + u2
-        v = v + v2
-        w = w + w2
-        u3, v3, w3 = mVORTEX(x, y, z, Xw[0,2,:], Xw[1,2,:], Xw[2,2,:], Xw[0,3,:], Xw[1,3,:], Xw[2,3,:], GAMw)
-        u = u + u3
-        v = v + v3
-        w = w + w3
-        u4, v4, w4 = mVORTEX(x, y, z, Xw[0,3,:], Xw[1,3,:], Xw[2,3,:], Xw[0,0,:], Xw[1,0,:], Xw[2,0,:], GAMw)
-        u = u + u4
-        v = v + v4
-        w = w + w4
-    
-        Vncw[i] += u * NC[0, i] + v * NC[1, i] + w * NC[2, i]
+    helper(Vncw, Xw, GAMw)
     
     GAMAw = GAMAw2_r[1, :]
     GAMw = np.reshape(GAMAw, nXw_r)
     Xw = Xw2_r[:, :, :nXw_r, 1]
-    for i in range(nXt):
-        x = XC[0, i]
-        y = XC[1, i]
-        z = XC[2, i]
-        u, v, w = 0, 0, 0
-    
-        u1, v1, w1 = mVORTEX(x, y, z, Xw[0,0,:], Xw[1,0,:], Xw[2,0,:], Xw[0,1,:], Xw[1,1,:], Xw[2,1,:], GAMw)
-        u = u + u1
-        v = v + v1
-        w = w + w1
-        u2, v2, w2 = mVORTEX(x, y, z, Xw[0,1,:], Xw[1,1,:], Xw[2,1,:], Xw[0,2,:], Xw[1,2,:], Xw[2,2,:], GAMw)
-        u = u + u2
-        v = v + v2
-        w = w + w2
-        u3, v3, w3 = mVORTEX(x, y, z, Xw[0,2,:], Xw[1,2,:], Xw[2,2,:], Xw[0,3,:], Xw[1,3,:], Xw[2,3,:], GAMw)
-        u = u + u3
-        v = v + v3
-        w = w + w3
-        u4, v4, w4 = mVORTEX(x, y, z, Xw[0,3,:], Xw[1,3,:], Xw[2,3,:], Xw[0,0,:], Xw[1,0,:], Xw[2,0,:], GAMw)
-        u = u + u4
-        v = v + v4
-        w = w + w4
-    
-        Vncw[i] += u * NC[0, i] + v * NC[1, i] + w * NC[2, i]     
+    helper(Vncw, Xw, GAMw)
 
     return Vncw

--- a/python_code/3d/s_impulse_WT.py
+++ b/python_code/3d/s_impulse_WT.py
@@ -73,13 +73,15 @@ def s_impulse_WT(istep, U, t, Xt, Xw, GAM, GAMAw, beta, phi, theta, a):
         aimpa[:,i] = aimp
 
         if istep > 0:
+            s = GAMAw.shape[1]  # Index limit to account for pre-allocation
+
             # Wake vortices
             # Linear impulse
-            n1, n2, limp = limpulse(Xw_T[:,:,:,i], GAMAw[i,:], beta[i], phi[i], theta[i], a[i])
+            n1, n2, limp = limpulse(Xw_T[:,:,:s,i], GAMAw[i,:], beta[i], phi[i], theta[i], a[i])
             limpw[:,i] = limp       # limpw(:,istep) + limp
 
             # Angular impulse
-            aimp = aimpulse(Xw_T[:,:,:,i], n1, n2, GAMAw[i,:], beta[i], phi[i], theta[i], a[i])
+            aimp = aimpulse(Xw_T[:,:,:s,i], n1, n2, GAMAw[i,:], beta[i], phi[i], theta[i], a[i])
             aimpw[:,i] = aimp       # aimpw(:,istep) + aimp
     
     return limpa, aimpa, limpw, aimpw

--- a/python_code/3d/tombo.py
+++ b/python_code/3d/tombo.py
@@ -78,14 +78,14 @@ def tombo():
 
     if g.nstep > 3:
         # Initialize the linear and angular impulse arrays
-        limpa_f = np.zeros((3, g.nstep, g.nwing))
-        limpa_r = np.zeros((3, g.nstep, g.nwing))
-        aimpa_f = np.zeros((3, g.nstep, g.nwing))
-        aimpa_r = np.zeros((3, g.nstep, g.nwing))
-        limpw_f = np.zeros((3, g.nstep, g.nwing))
-        limpw_r = np.zeros((3, g.nstep, g.nwing))
-        aimpw_f = np.zeros((3, g.nstep, g.nwing))
-        aimpw_r = np.zeros((3, g.nstep, g.nwing))
+        g.limpa_f = np.zeros((3, g.nstep, g.nwing))
+        g.limpa_r = np.zeros((3, g.nstep, g.nwing))
+        g.aimpa_f = np.zeros((3, g.nstep, g.nwing))
+        g.aimpa_r = np.zeros((3, g.nstep, g.nwing))
+        g.limpw_f = np.zeros((3, g.nstep, g.nwing))
+        g.limpw_r = np.zeros((3, g.nstep, g.nwing))
+        g.aimpw_f = np.zeros((3, g.nstep, g.nwing))
+        g.aimpw_r = np.zeros((3, g.nstep, g.nwing))
 
     # Normal velocity on the wing due to the wing motion & wake vortices
     Vnc_f  = np.zeros((g.nwing, nxt_f))
@@ -240,20 +240,20 @@ def tombo():
                              beta[0:2], phi[0:2], theta[0:2], a[0:2])
             for j in range(3):
                 for w in range(g.nwing):
-                    limpa_f[j, g.istep, w] = limpa[j, w]
-                    aimpa_f[j, g.istep, w] = aimpa[j, w]
-                    limpw_f[j, g.istep, w] = limpw[j, w]
-                    aimpw_f[j, g.istep, w] = aimpw[j, w]
+                    g.limpa_f[j, g.istep, w] = limpa[j, w]
+                    g.aimpa_f[j, g.istep, w] = aimpa[j, w]
+                    g.limpw_f[j, g.istep, w] = limpw[j, w]
+                    g.aimpw_f[j, g.istep, w] = aimpw[j, w]
             # Rear wing
             limpa, aimpa, limpw, aimpw = \
                 s_impulse_WT(g.istep, U, t, Xt_r, Xw_r, GAM_r, GAMw_r,
                              beta[2:4], phi[2:4], theta[2:4], a[2:4]) 
             for j in range(3):
                 for w in range(g.nwing):
-                    limpa_r[j, g.istep, w] = limpa[j, w]
-                    aimpa_r[j, g.istep, w] = aimpa[j, w]
-                    limpw_r[j, g.istep, w] = limpw[j, w]
-                    aimpw_r[j, g.istep, w] = aimpw[j, w]  
+                    g.limpa_r[j, g.istep, w] = limpa[j, w]
+                    g.aimpa_r[j, g.istep, w] = aimpa[j, w]
+                    g.limpw_r[j, g.istep, w] = limpw[j, w]
+                    g.aimpw_r[j, g.istep, w] = aimpw[j, w]  
 
         # Extract GAMAb (border & shed ) from GAM
         GAMAb_f = divide_GAM(GAM_f, g.nxb_f)

--- a/python_code/3d/tombo.py
+++ b/python_code/3d/tombo.py
@@ -69,8 +69,8 @@ def tombo():
     # Total wake vortex number
     nxw_f = 0; nxw_r = 0
     # Wake vortex location array (after convection)
-    Xw_f = np.zeros((3, 4, g.nxb_f, g.nwing))
-    Xw_r = np.zeros((3, 4, g.nxb_r, g.nwing))
+    Xw_f = np.zeros((3, 4, g.nxb_f*g.nstep, g.nwing))
+    Xw_r = np.zeros((3, 4, g.nxb_r*g.nstep, g.nwing))
     # Shed vortex location array 
     Xs_f = np.zeros((3, 4, g.nxb_f, g.nwing))
     Xs_r = np.zeros((3, 4, g.nxb_r, g.nwing))
@@ -297,34 +297,34 @@ def tombo():
             # Velocity of the wake elements due to total wing vortices
             for i in range(g.nwing):
                 # TODO: pre-allocate
-                VWT_f[:3, :4, :(g.istep-1)*g.nxb_f, i] = vel_by(g.istep, Xw_f[:,:,:,i], nxw_f, Xt_f, GAM_f, nxt_f, Xt_r, GAM_r, nxt_r)
-                VWT_r[:3, :4, :(g.istep-1)*g.nxb_r, i] = vel_by(g.istep, Xw_r[:,:,:,i], nxw_r, Xt_f, GAM_f, nxt_f, Xt_r, GAM_r, nxt_r)
+                VWT_f[:3, :4, :g.istep*g.nxb_f, i] = vel_by(g.istep, Xw_f[:,:,:,i], nxw_f, Xt_f, GAM_f, nxt_f, Xt_r, GAM_r, nxt_r)
+                VWT_r[:3, :4, :g.istep*g.nxb_r, i] = vel_by(g.istep, Xw_r[:,:,:,i], nxw_r, Xt_f, GAM_f, nxt_f, Xt_r, GAM_r, nxt_r)
             
             # Velocity of the wake elements due to wake elements
             for i in range(g.nwing):
                 # TODO: pre-allocate
-                VWW_f[:3, :4, :(g.istep-1)*g.nxb_f, i] = vel_by(g.istep, Xw_f[:,:,:,i], nxw_f, Xw_f, GAMw_f, nxw_f, Xw_r, GAMw_r, nxw_r)
-                VWW_r[:3, :4, :(g.istep-1)*g.nxb_r, i] = vel_by(g.istep, Xw_r[:,:,:,i], nxw_r, Xw_f, GAMw_f, nxw_f, Xw_r, GAMw_r, nxw_r)
+                VWW_f[:3, :4, :g.istep*g.nxb_f, i] = vel_by(g.istep, Xw_f[:,:,:,i], nxw_f, Xw_f, GAMw_f, nxw_f, Xw_r, GAMw_r, nxw_r)
+                VWW_r[:3, :4, :g.istep*g.nxb_r, i] = vel_by(g.istep, Xw_r[:,:,:,i], nxw_r, Xw_f, GAMw_f, nxw_f, Xw_r, GAMw_r, nxw_r)
 
         # Shed border vortex elements
         Xs_f = Xb_f + g.dt * (VBT_f + VBW_f)
         Xs_r = Xb_r + g.dt * (VBT_r + VBW_r)
 
         # Convect wake vortices
-        # if g.istep > 0:
-        #     Xw_f = Xw_f + g.dt * (VWT_f + VWW_f)
-        #     Xw_r = Xw_r + g.dt * (VWT_f + VWW_f)
+        if g.istep > 0:
+            Xw_f = Xw_f + g.dt * (VWT_f + VWW_f)
+            Xw_r = Xw_r + g.dt * (VWT_f + VWW_f)
 
         # Add shed vortices to wake vortex
         if g.istep == 0:
             # Front wings
             GAMw_f = GAMAb_f
             nxw_f = g.nxb_f
-            Xw_f = Xs_f
+            Xw_f[:, :, :10, :] = Xs_f
             # Rear wings
             GAMw_r = GAMAb_r
             nxw_r = g.nxb_r
-            Xw_r = Xs_r
+            Xw_r[:, :, :10, :] = Xs_r
         else:
             # TODO: pre-allocate Xw_f, Xw_r
             GAMw_f, nxw_f, Xw_f = add_wake(g.nxb_f, GAMAb_f, Xs_f, GAMw_f, Xw_f)

--- a/python_code/3d/tombo.py
+++ b/python_code/3d/tombo.py
@@ -297,13 +297,11 @@ def tombo():
         
             # Velocity of the wake elements due to total wing vortices
             for i in range(g.nwing):
-                # TODO: pre-allocate
                 VWT_f[:3, :4, :g.istep*g.nxb_f, i] = vel_by(g.istep, Xw_f[:,:,:,i], nxw_f, Xt_f, GAM_f, nxt_f, Xt_r, GAM_r, nxt_r)
                 VWT_r[:3, :4, :g.istep*g.nxb_r, i] = vel_by(g.istep, Xw_r[:,:,:,i], nxw_r, Xt_f, GAM_f, nxt_f, Xt_r, GAM_r, nxt_r)
             
             # Velocity of the wake elements due to wake elements
             for i in range(g.nwing):
-                # TODO: pre-allocate
                 VWW_f[:3, :4, :g.istep*g.nxb_f, i] = vel_by(g.istep, Xw_f[:,:,:,i], nxw_f, Xw_f, GAMw_f, nxw_f, Xw_r, GAMw_r, nxw_r)
                 VWW_r[:3, :4, :g.istep*g.nxb_r, i] = vel_by(g.istep, Xw_r[:,:,:,i], nxw_r, Xw_f, GAMw_f, nxw_f, Xw_r, GAMw_r, nxw_r)
 
@@ -327,7 +325,6 @@ def tombo():
             nxw_r = g.nxb_r
             Xw_r[:, :, :10, :] = Xs_r
         else:
-            # TODO: pre-allocate Xw_f, Xw_r
             GAMw_f, nxw_f, Xw_f = add_wake(g.nxb_f, GAMAb_f, Xs_f, GAMw_f, Xw_f)
             GAMw_r, nxw_r, Xw_r = add_wake(g.nxb_r, GAMAb_r, Xs_r, GAMw_r, Xw_r)
 

--- a/python_code/3d/vel_by.py
+++ b/python_code/3d/vel_by.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+def vel_by(istep, Xb, nXb, Xw2_f, GAMAw2_f, nXw_f, Xw2_r, GAMAw2_r, nXw_r):
+    """
+    Calculate velocity at target nodes due to source vortices
+
+    This is a generalization of `tbvelBbyW`, `tbvelWbyT`, and
+    `tbvelWbyW`
+
+    Parameters
+    ----------
+    istep: int
+        Current iteration step
+    Xw: ndarray[j, n, iXw]
+        Coordinate j of observation node n of the target element node
+    nXw: int
+        Number of target elements
+    Xt2_f: ndarray[j, n, iXt, w]
+        Coordinate j of source node n for source elements on front wings
+    GAMA2_f: ndarray[w, iXt]
+        Source elements on front wings
+    nXt_f: int
+        Number of source elements on front wings
+    Xt2_r: ndarray[j, n, iXt, w]
+        Coordinate j of source node n for source elements on rear wings
+    GAMA2_r: ndarray[w, iXt]
+        Source elements on rear wings
+    nXt_r: int
+        Number of total elements on rear wings 
+    """
+    pass

--- a/python_code/3d/vel_by.py
+++ b/python_code/3d/vel_by.py
@@ -47,17 +47,17 @@ def vel_by(istep, X_target, nX_target, X_f, GAMA_f, nX_f, X_r, GAMA_r, nX_r):
                 v += v1
                 w += w1
                 u2, v2, w2 = mVORTEX(x, y, z, X[0,1,:], X[1,1,:], X[2,1,:], X[0,2,:], X[1,2,:], X[2,2,:], GAM)
-                u += u1
-                v += v1
-                w += w1
+                u += u2
+                v += v2
+                w += w2
                 u3, v3, w3 = mVORTEX(x, y, z, X[0,2,:], X[1,2,:], X[2,2,:], X[0,3,:], X[1,3,:], X[2,3,:], GAM)
-                u += u1
-                v += v1
-                w += w1
+                u += u3
+                v += v3
+                w += w3
                 u4, v4, w4 = mVORTEX(x, y, z, X[0,3,:], X[1,3,:], X[2,3,:], X[0,0,:], X[1,0,:], X[2,0,:], GAM)
-                u += u1
-                v += v1
-                w += w1
+                u += u4
+                v += v4
+                w += w4
 
                 vel[0, n, i] += u
                 vel[1, n, i] += v

--- a/python_code/3d/vel_by.py
+++ b/python_code/3d/vel_by.py
@@ -73,26 +73,26 @@ def vel_by(istep, X_target, nX_target, X_f, GAMA_f, nX_f, X_r, GAMA_r, nX_r):
     # Contribution from right wing
     GAMA = GAMA_f[0,:]
     GAM = np.reshape(GAMA, nX_f)
-    X = X_f[:,:,:,0]
+    X = X_f[:,:,:nX_f,0]
     helper(vel, X, GAM)
 
     # Contribution from left wing
     GAMA = GAMA_f[1,:]
     GAM = np.reshape(GAMA, nX_f)
-    X = X_f[:,:,:,1]
+    X = X_f[:,:,:nX_f,1]
     helper(vel, X, GAM)
 
     # Rear wings
     # Contribution from right wing
     GAMA = GAMA_r[0,:]
     GAM = np.reshape(GAMA, nX_r)
-    X = X_r[:,:,:,0]
+    X = X_r[:,:,:nX_r,0]
     helper(vel, X, GAM)
 
     # Contribution from left wing
     GAMA = GAMA_r[1,:]
     GAM = np.reshape(GAMA, nX_r)
-    X = X_r[:,:,:,1]
+    X = X_r[:,:,:nX_r,1]
     helper(vel, X, GAM)
 
     return vel

--- a/python_code/3d/vel_by.py
+++ b/python_code/3d/vel_by.py
@@ -37,9 +37,9 @@ def vel_by(istep, X_target, nX_target, X_f, GAMA_f, nX_f, X_r, GAMA_r, nX_r):
     def helper(vel, X, GAMA):
         for i in range(nX_target):
             for n in range(4):
-                x = X_target(0, n, i)
-                y = X_target(1, n, i)
-                z = X_target(2, n, i)
+                x = X_target[0, n, i]
+                y = X_target[1, n, i]
+                z = X_target[2, n, i]
                 u, v, w = 0, 0, 0
 
                 u1, v1, w1 = mVORTEX(x, y, z, X[0,0,:], X[1,0,:], X[2,0,:], X[0,1,:], X[1,1,:], X[2,1,:], GAMA)

--- a/python_code/3d/vel_by.py
+++ b/python_code/3d/vel_by.py
@@ -34,7 +34,7 @@ def vel_by(istep, X_target, nX_target, X_f, GAMA_f, nX_f, X_r, GAMA_r, nX_r):
     vel: ndarray[j, n, iXb]
         Induced velocity
     """
-    def helper(vel, X, GAMA):
+    def helper(vel, X, GAM):
         for i in range(nX_target):
             for n in range(4):
                 x = X_target[0, n, i]
@@ -42,19 +42,19 @@ def vel_by(istep, X_target, nX_target, X_f, GAMA_f, nX_f, X_r, GAMA_r, nX_r):
                 z = X_target[2, n, i]
                 u, v, w = 0, 0, 0
 
-                u1, v1, w1 = mVORTEX(x, y, z, X[0,0,:], X[1,0,:], X[2,0,:], X[0,1,:], X[1,1,:], X[2,1,:], GAMA)
+                u1, v1, w1 = mVORTEX(x, y, z, X[0,0,:], X[1,0,:], X[2,0,:], X[0,1,:], X[1,1,:], X[2,1,:], GAM)
                 u += u1
                 v += v1
                 w += w1
-                u2, v2, w2 = mVORTEX(x, y, z, X[0,1,:], X[1,1,:], X[2,1,:], X[0,2,:], X[1,2,:], X[2,2,:], GAMA)
+                u2, v2, w2 = mVORTEX(x, y, z, X[0,1,:], X[1,1,:], X[2,1,:], X[0,2,:], X[1,2,:], X[2,2,:], GAM)
                 u += u1
                 v += v1
                 w += w1
-                u3, v3, w3 = mVORTEX(x, y, z, X[0,2,:], X[1,2,:], X[2,2,:], X[0,3,:], X[1,3,:], X[2,3,:], GAMA)
+                u3, v3, w3 = mVORTEX(x, y, z, X[0,2,:], X[1,2,:], X[2,2,:], X[0,3,:], X[1,3,:], X[2,3,:], GAM)
                 u += u1
                 v += v1
                 w += w1
-                u4, v4, w4 = mVORTEX(x, y, z, X[0,3,:], X[1,3,:], X[2,3,:], X[0,0,:], X[1,0,:], X[2,0,:], GAMA)
+                u4, v4, w4 = mVORTEX(x, y, z, X[0,3,:], X[1,3,:], X[2,3,:], X[0,0,:], X[1,0,:], X[2,0,:], GAM)
                 u += u1
                 v += v1
                 w += w1
@@ -71,28 +71,28 @@ def vel_by(istep, X_target, nX_target, X_f, GAMA_f, nX_f, X_r, GAMA_r, nX_r):
 
     # Front wings
     # Contribution from right wing
-    GAMAw = GAMA_f[0,:]
-    GAMw = np.reshape(GAMAw, nX_f)
-    Xw = X_f[:,:,:,0]
-    helper(vel, Xw, GAMw)
+    GAMA = GAMA_f[0,:]
+    GAM = np.reshape(GAMA, nX_f)
+    X = X_f[:,:,:,0]
+    helper(vel, X, GAM)
 
     # Contribution from left wing
-    GAMAw = GAMA_f[1,:]
-    GAMw = np.reshape(GAMAw, nX_f)
-    Xw = X_f[:,:,:,1]
-    helper(vel, Xw, GAMAw)
+    GAMA = GAMA_f[1,:]
+    GAM = np.reshape(GAMA, nX_f)
+    X = X_f[:,:,:,1]
+    helper(vel, X, GAM)
 
     # Rear wings
     # Contribution from right wing
-    GAMAw = GAMA_r[0,:]
-    GAMw = np.reshape(GAMAw, nX_r)
-    Xw = X_r[:,:,:,0]
-    helper(vel, Xw, GAMw)
+    GAMA = GAMA_r[0,:]
+    GAM = np.reshape(GAMA, nX_r)
+    X = X_r[:,:,:,0]
+    helper(vel, X, GAM)
 
     # Contribution from left wing
-    GAMAw = GAMA_r[1,:]
-    GAMw = np.reshape(GAMAw, nX_r)
-    Xw = X_r[:,:,:,1]
-    helper(vel, Xw, GAMAw)
+    GAMA = GAMA_r[1,:]
+    GAM = np.reshape(GAMA, nX_r)
+    X = X_r[:,:,:,1]
+    helper(vel, X, GAM)
 
     return vel


### PR DESCRIPTION
This PR implements the `vel_by()` function, which is a generalization of `tbvelBbyW`, `tbvelWbyT`, and `tbvelWbyW`.

This required pre-allocation of several arrays, and many other functions have been fixed to support this pre-allocation. The main function `tombo()` now runs all the way through, and I have tested that the output matches the Matlab code other than a bit or rounding error.

