### PR TITLE
Remove g as a class

### DIFF
--- a/python_code/3d/VORTEXm.py
+++ b/python_code/3d/VORTEXm.py
@@ -1,5 +1,5 @@
 import numpy as np
-from globals import g
+import globals as g
 
 def VORTEXm(x, y, z, X1, Y1, Z1, X2, Y2, Z2, GAMA):
     """

--- a/python_code/3d/add_wake.py
+++ b/python_code/3d/add_wake.py
@@ -1,5 +1,5 @@
 import numpy as np
-from globals import g
+import globals as g
 
 def add_wake(nXb, GAMAb, Xs, GAMAw, Xw):
     """

--- a/python_code/3d/assemble_vel_B_by_T.py
+++ b/python_code/3d/assemble_vel_B_by_T.py
@@ -1,5 +1,5 @@
 import numpy as np
-from globals import g
+import globals as g
 
 def assemble_vel_B_by_T(nxb_f, VBTs_f, VBTs_12, VBTs_13, VBTs_14, VBTs_21, VBTs_23, VBTs_24,
                         nxb_r, VBTs_r, VBTs_31, VBTs_32, VBTs_34, VBTs_41, VBTs_42, VBTs_43

--- a/python_code/3d/b_vel_B_by_T_matrix.py
+++ b/python_code/3d/b_vel_B_by_T_matrix.py
@@ -1,7 +1,7 @@
 import numpy as np
 from scipy.io import loadmat
 
-from globals import g
+import globals as g
 from VORTEXm import VORTEXm
 
 

--- a/python_code/3d/divide_GAM.py
+++ b/python_code/3d/divide_GAM.py
@@ -1,5 +1,5 @@
 import numpy as np
-from globals import g
+import globals as g
 
 def divide_GAM(GAM, nxb):
     """

--- a/python_code/3d/force_moment.py
+++ b/python_code/3d/force_moment.py
@@ -1,7 +1,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy.interpolate import splev, splrep, splder
-from globals import g
+import globals as g
 
 def force_moment(rho_, v_, d_1, nstep, dt, U):
     # Reference values of force and moment

--- a/python_code/3d/globals.py
+++ b/python_code/3d/globals.py
@@ -1,251 +1,250 @@
 import numpy as np
 import numpy.typing as npt
 
-class g:
-    # General configuration
-    # ---------------------
+# General configuration
+# ---------------------
 
-    stime: bool = True
-    """
-    Time specification:
-    - multiple times (False),
-    - time marching (True)
-    """
-    solver: bool = False
-    """
-    Linear equation solver: 
-    - forward elim/backward sub (False),
-    - backslash (True)
-    """
-
-
-    # Output files
-    # ------------
-
-    folder: str = 'fig/'
-    """Path to output folder"""
-    # fid = open(f"{folder}/output.txt", 'w')
-    """Output file"""
+stime: bool = True
+"""
+Time specification:
+- multiple times (False),
+- time marching (True)
+"""
+solver: bool = False
+"""
+Linear equation solver: 
+- forward elim/backward sub (False),
+- backslash (True)
+"""
 
 
-    # Plotting
-    # --------
+# Output files
+# ------------
 
-    iplot: bool = True
-    """Toggle chord path plot"""
-    mplot: bool = True
-    """Toggle airfoil mesh plot"""
-    vplot: bool = True
-    """Toggle airfoil normal velocity plot"""
-    gplot: bool = True
-    """Toggle gamma plot"""
-    wplot: bool = True
-    """Toggle wake vortex plot"""
-    idebg: bool = False
-    """Toggle debug prints"""
+folder: str = 'fig/'
+"""Path to output folder"""
+# fid = open(f"{folder}/output.txt", 'w')
+"""Output file"""
 
 
-    # Time
-    # ----
+# Plotting
+# --------
 
-    t_: float = None
-    """Reference time"""
-    dt: float = 0.1
-    """Time increment"""
-    nstep: int = 4
-    """Number of time steps to iterate through"""
-    istep: int = 0
-    """Current iteration step"""
-
-
-    # Body geometry
-    # -------------
-
-    twing: int = 4
-    """Total number of wings"""
-    nwing: int = twing // 2
-    """Number of wings in fore/rear"""
-    delta_: float = 0.0
-    """Body angle in degrees"""
-    b_f: float = -1.5
-    """Fore wing location in cm"""
-    b_r: float = 1.5
-    """Rear wing location in cm"""
+iplot: bool = True
+"""Toggle chord path plot"""
+mplot: bool = True
+"""Toggle airfoil mesh plot"""
+vplot: bool = True
+"""Toggle airfoil normal velocity plot"""
+gplot: bool = True
+"""Toggle gamma plot"""
+wplot: bool = True
+"""Toggle wake vortex plot"""
+idebg: bool = True
+"""Toggle debug prints"""
 
 
-    # Wing geometry
-    # -------------
+# Time
+# ----
 
-    # General
-
-    itaper: bool = True
-    """Toggle wing taper"""
-    # TODO: maybe add taper or bang_ global var
-    c_: float = None
-    """Wing chord length (used temporarily)"""
-    l_: float = None
-    """Wing span length (used temporarily)"""
-    icamber: int = 0
-    """
-    Camber direction: 
-    - `0`: no camber
-    - `1`: x-direction
-    - `2`: y-direction
-    - `3`: both directions"""
-    acamber: float = 0.2
-    """Camber amplitude"""
-    hfactor: float = None
-    """
-    TODO
-    Ratio of wing height to chord length:
-    - `0.1`: high aspect ratio wing (`chord < span`)
-    - `<= 0.05`: low aspect ratio wing (`chord > span`)
-    """
-
-    # Front wing
-
-    xb_f = None
-    """Border element coordinates (front)"""
-    nxb_f = None
-    """Number of border elements (front)"""
-    nb_f = None
-    """Unit normal to the border elements (front)"""
-    xc_f = None
-    """Center element coordinates (front)"""
-    nxc_f = None
-    """Number of center elements (front)"""
-    nc_f = None
-    """Unit normal to the center elements (front)"""
-    l_f = None
-    """Wing span (front)"""
-    c_f = None
-    """Wing chord length (front)"""
-    h_f = None
-    """Border height (front)"""
-
-    # Rear wing
-
-    xb_r = None
-    """Border element coordinates (rear)"""
-    nxb_r = None
-    """Number of border elements (rear)"""
-    nb_r = None
-    """Unit normal to the border elements (rear)"""
-    xc_r = None
-    """Center element coordinates (rear)"""
-    nxc_r = None
-    """Number of center elements (rear)"""
-    nc_r = None
-    """Unit normal to the center elements (rear)"""
-    l_r = None
-    """Wing span (rear)"""
-    c_r = None
-    """Wing chord length (rear)"""
-    h_r = None
-    """Border height (rear)"""
+t_: float = None
+"""Reference time"""
+dt: float = 0.1
+"""Time increment"""
+nstep: int = 4
+"""Number of time steps to iterate through"""
+istep: int = 0
+"""Current iteration step"""
 
 
-    # Wing motion
-    # -----------
+# Body geometry
+# -------------
 
-    v_: float = None
-    """Reference velocity"""
-    d_: npt.NDArray[np.floating] = None
-    """Total stroke length"""
-    phiT_: npt.NDArray[np.floating] = np.array([80.0, 80.0, 80.0, 80.0])
-    """Top stroke angle in degrees"""
-    phiB_: npt.NDArray[np.floating] = np.array([-45.0, -45.0, -45.0, -45.0])
-    """Bottom stroke angle in degrees"""
-    a_: npt.NDArray[np.floating] = np.array([0.0, 0.0, 0.0, 0.0])
-    """Rotation axis offset in cm"""
-    beta_: npt.NDArray[np.floating] = np.array([90.0, 90.0, 90.0, 90.0])
-    """Stroke plane angle in degrees wrt the body axis"""
-    f_: npt.NDArray[np.floating] = np.array([30.0, 30.0, 30.0, 30.0])
-    """Flapping frequency in Hz"""
-    gMax_: npt.NDArray[np.floating] = np.array([30.0, 30.0, 30.0, 30.0])
-    """Max rotation amplitude in degrees; actual rotation is `2*gMax`"""
-    p: npt.NDArray[np.floating] = np.array([5.0, 5.0, 5.0, 5.0])
-    """Rotation speed parameter (nondimensional); `p >= 4`"""
-    rtOff: npt.NDArray[np.floating] = np.array([0.0, 0.0, 0.0, 0.0])
-    """
-    Rotation timing offset (nondimensional):
-    - `-0.5 < rtOff < 0.5`
-    - `rtOff < 0` (advanced), 
-    - `rtOff = 0` (symmetric),
-    - `rtOff > 0` (delayed);
-    """
-    tau: npt.NDArray[np.floating] = np.array([0.0, 0.0, 0.0, 0.0])
-    """
-    Phase shift for the time (nondimensional):
-    - `0 <= tau < 2`
-    - `tau = 0` (start from top, start with down stroke)
-    - `0 < tau < 1` (start in between, start with down stroke)
-    - `tau = 1` (start from bottom, start wtih up stroke)
-    - `1 < tau < 2` (start in between, start with up stroke)
-    """
-    mpath: npt.NDArray[np.integer] = np.array([0, 0, 0, 0])
-    """
-    Motion path parameter:
-    - `0`: noTail Standard flapping(sinusoidal) & rotation (smoothed step func)
-    - `1`: `td = 1` (DUTail), `nhp = 4` (2 periods)     
-    - `2`: `td = 2` (UDTail), `nhp = 4` (2 periods) 
-    - `3`: `td = 1` (DUDUTail), `nhp = 8` (4 periods) 
-    - `4`: `td = 2` (UDUDTail), `nhp = 8` (4 periods) 
-    - `5`: ctct(UDTailUTail), nhp = 4
-    """
+twing: int = 4
+"""Total number of wings"""
+nwing: int = twing // 2
+"""Number of wings in fore/rear"""
+delta_: float = 0.0
+"""Body angle in degrees"""
+b_f: float = -1.5
+"""Fore wing location in cm"""
+b_r: float = 1.5
+"""Rear wing location in cm"""
 
 
-    # Fluid
-    # -----
+# Wing geometry
+# -------------
 
-    rho_: float = 0.001225
-    """Air density"""
-    U_: npt.NDArray[np.floating] = np.array([100.0, 0.0, 0.0])
-    """
-    Ambient velocity in (x, y, z); can be interpreted as the flight velocity
-    when the wind is calm
-    """
+# General
+
+itaper: bool = True
+"""Toggle wing taper"""
+# TODO: maybe add taper or bang_ global var
+c_: float = None
+"""Wing chord length (used temporarily)"""
+l_: float = None
+"""Wing span length (used temporarily)"""
+icamber: int = 0
+"""
+Camber direction: 
+- `0`: no camber
+- `1`: x-direction
+- `2`: y-direction
+- `3`: both directions"""
+acamber: float = 0.2
+"""Camber amplitude"""
+hfactor: float = None
+"""
+TODO
+Ratio of wing height to chord length:
+- `0.1`: high aspect ratio wing (`chord < span`)
+- `<= 0.05`: low aspect ratio wing (`chord > span`)
+"""
+
+# Front wing
+
+xb_f = None
+"""Border element coordinates (front)"""
+nxb_f = None
+"""Number of border elements (front)"""
+nb_f = None
+"""Unit normal to the border elements (front)"""
+xc_f = None
+"""Center element coordinates (front)"""
+nxc_f = None
+"""Number of center elements (front)"""
+nc_f = None
+"""Unit normal to the center elements (front)"""
+l_f = None
+"""Wing span (front)"""
+c_f = None
+"""Wing chord length (front)"""
+h_f = None
+"""Border height (front)"""
+
+# Rear wing
+
+xb_r = None
+"""Border element coordinates (rear)"""
+nxb_r = None
+"""Number of border elements (rear)"""
+nb_r = None
+"""Unit normal to the border elements (rear)"""
+xc_r = None
+"""Center element coordinates (rear)"""
+nxc_r = None
+"""Number of center elements (rear)"""
+nc_r = None
+"""Unit normal to the center elements (rear)"""
+l_r = None
+"""Wing span (rear)"""
+c_r = None
+"""Wing chord length (rear)"""
+h_r = None
+"""Border height (rear)"""
 
 
-    # Cutoffs (error)
-    # ---------------
-    
-    RCUT: float = 1.0e-10
-    """Distance between source and observation points to be judged as zero"""
-    LCUT: float = None
-    """
-    Cutoff distance of the extension of a vortex line; velocity evaluation points
-    within this distance from the vortex line and/or its extension is set to zero
-    """
+# Wing motion
+# -----------
 
-    # Impulse arrays
-    # --------------
+v_: float = None
+"""Reference velocity"""
+d_: npt.NDArray[np.floating] = None
+"""Total stroke length"""
+phiT_: npt.NDArray[np.floating] = np.array([80.0, 80.0, 80.0, 80.0])
+"""Top stroke angle in degrees"""
+phiB_: npt.NDArray[np.floating] = np.array([-45.0, -45.0, -45.0, -45.0])
+"""Bottom stroke angle in degrees"""
+a_: npt.NDArray[np.floating] = np.array([0.0, 0.0, 0.0, 0.0])
+"""Rotation axis offset in cm"""
+beta_: npt.NDArray[np.floating] = np.array([90.0, 90.0, 90.0, 90.0])
+"""Stroke plane angle in degrees wrt the body axis"""
+f_: npt.NDArray[np.floating] = np.array([30.0, 30.0, 30.0, 30.0])
+"""Flapping frequency in Hz"""
+gMax_: npt.NDArray[np.floating] = np.array([30.0, 30.0, 30.0, 30.0])
+"""Max rotation amplitude in degrees; actual rotation is `2*gMax`"""
+p: npt.NDArray[np.floating] = np.array([5.0, 5.0, 5.0, 5.0])
+"""Rotation speed parameter (nondimensional); `p >= 4`"""
+rtOff: npt.NDArray[np.floating] = np.array([0.0, 0.0, 0.0, 0.0])
+"""
+Rotation timing offset (nondimensional):
+- `-0.5 < rtOff < 0.5`
+- `rtOff < 0` (advanced), 
+- `rtOff = 0` (symmetric),
+- `rtOff > 0` (delayed);
+"""
+tau: npt.NDArray[np.floating] = np.array([0.0, 0.0, 0.0, 0.0])
+"""
+Phase shift for the time (nondimensional):
+- `0 <= tau < 2`
+- `tau = 0` (start from top, start with down stroke)
+- `0 < tau < 1` (start in between, start with down stroke)
+- `tau = 1` (start from bottom, start wtih up stroke)
+- `1 < tau < 2` (start in between, start with up stroke)
+"""
+mpath: npt.NDArray[np.integer] = np.array([0, 0, 0, 0])
+"""
+Motion path parameter:
+- `0`: noTail Standard flapping(sinusoidal) & rotation (smoothed step func)
+- `1`: `td = 1` (DUTail), `nhp = 4` (2 periods)     
+- `2`: `td = 2` (UDTail), `nhp = 4` (2 periods) 
+- `3`: `td = 1` (DUDUTail), `nhp = 8` (4 periods) 
+- `4`: `td = 2` (UDUDTail), `nhp = 8` (4 periods) 
+- `5`: ctct(UDTailUTail), nhp = 4
+"""
 
-    limpa_f = None
-    """Linear impulse from bound vortices (front)"""
-    aimpa_f = None
-    """Angular impulse from bound vortices (front)"""
-    limpw_f = None
-    """Linear impulse from wake vortices (front)"""
-    aimpw_f = None
-    """Angular impulse from wake vortices (front)"""
-    limpa_r = None
-    """Linear impulse from bound vortices (rear)"""
-    aimpa_r = None
-    """Angular impulse from bound vortices (rear)"""
-    limpw_r = None
-    """Linear impulse from wake vortices (rear)"""
-    aimpw_r = None
-    """Angular impulse from wake vortices (rear)"""
+
+# Fluid
+# -----
+
+rho_: float = 0.001225
+"""Air density"""
+U_: npt.NDArray[np.floating] = np.array([100.0, 0.0, 0.0])
+"""
+Ambient velocity in (x, y, z); can be interpreted as the flight velocity
+when the wind is calm
+"""
 
 
-    # TODO: Finish below
+# Cutoffs (error)
+# ---------------
 
-    wfactor: float = None
-    """Ratio of element width to wing height"""
-    ielong: bool  = False
-    """Toggle fixed number of border elements"""
-    h_: float = None
-    """Height of each border strip"""
+RCUT: float = 1.0e-10
+"""Distance between source and observation points to be judged as zero"""
+LCUT: float = None
+"""
+Cutoff distance of the extension of a vortex line; velocity evaluation points
+within this distance from the vortex line and/or its extension is set to zero
+"""
 
-    rt = None
+# Impulse arrays
+# --------------
+
+limpa_f = None
+"""Linear impulse from bound vortices (front)"""
+aimpa_f = None
+"""Angular impulse from bound vortices (front)"""
+limpw_f = None
+"""Linear impulse from wake vortices (front)"""
+aimpw_f = None
+"""Angular impulse from wake vortices (front)"""
+limpa_r = None
+"""Linear impulse from bound vortices (rear)"""
+aimpa_r = None
+"""Angular impulse from bound vortices (rear)"""
+limpw_r = None
+"""Linear impulse from wake vortices (rear)"""
+aimpw_r = None
+"""Angular impulse from wake vortices (rear)"""
+
+
+# TODO: Finish below
+
+wfactor: float = None
+"""Ratio of element width to wing height"""
+ielong: bool  = False
+"""Toggle fixed number of border elements"""
+h_: float = None
+"""Height of each border strip"""
+
+rt = None

--- a/python_code/3d/lrs_wing_NVs.py
+++ b/python_code/3d/lrs_wing_NVs.py
@@ -1,6 +1,6 @@
 import numpy as np
 from matplotlib import pyplot as plt
-from globals import g
+import globals as g
 
 def lrs_wing_NVs(m, iwing, xC, XC, NC, t, theta, phi, dph, dth, a, beta, U):
     """

--- a/python_code/3d/mVORTEX.py
+++ b/python_code/3d/mVORTEX.py
@@ -1,5 +1,5 @@
 import numpy as np
-from globals import g
+import globals as g
 
 def mVORTEX(x, y, z, X1, Y1, Z1, X2, Y2, Z2, GAMA):
     """

--- a/python_code/3d/nd_data.py
+++ b/python_code/3d/nd_data.py
@@ -1,5 +1,5 @@
 import numpy as np
-from globals import g
+import globals as g
 
 def nd_data(
         l_f, 

--- a/python_code/3d/plot_GAM.py
+++ b/python_code/3d/plot_GAM.py
@@ -1,6 +1,6 @@
 import matplotlib.pyplot as plt
 import numpy as np
-from globals import g
+import globals as g
 
 def plot_GAM(m, iwing, t, GAMA, XC, NC):
     # Plot GAMA at the collocation points of elements using the normal direction

--- a/python_code/3d/plot_WB.py
+++ b/python_code/3d/plot_WB.py
@@ -1,6 +1,6 @@
 import numpy as np
 import matplotlib.pyplot as plt
-from globals import g
+import globals as g
 
 def plot_WB(istep, nXb_f, nXw_f, Xb_f, Xw_f, nXb_r, nXw_r, Xb_r, Xw_r):
     """

--- a/python_code/3d/s_impulse_WT.py
+++ b/python_code/3d/s_impulse_WT.py
@@ -1,5 +1,5 @@
 import numpy as np
-from globals import g
+import globals as g
 
 # TODO: Remove unused parameters beta, phi, theta
 def s_impulse_WT(istep, U, t, Xt, Xw, GAM, GAMAw, beta, phi, theta, a):

--- a/python_code/3d/solution.py
+++ b/python_code/3d/solution.py
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy.linalg import lu_factor, lu_solve
-from globals import g
+import globals as g
 
 def solution(nxt_f, nxt_r, MVN, Vnc_f, Vncw_f, Vnc_r, Vncw_r):
     """

--- a/python_code/3d/tombo.py
+++ b/python_code/3d/tombo.py
@@ -6,7 +6,7 @@ plt.ioff()
 
 from scipy.io import loadmat
 
-from globals import g
+import globals as g
 from wing import wing
 from nd_data import nd_data
 from wing_total import wing_total

--- a/python_code/3d/vel_B_by_T.py
+++ b/python_code/3d/vel_B_by_T.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from globals import g
+import globals as g
 
 
 def vel_B_by_T(cVBT, GAM, nXt):

--- a/python_code/3d/wing.py
+++ b/python_code/3d/wing.py
@@ -1,5 +1,5 @@
 import numpy as np
-from globals import g
+import globals as g
 import matplotlib.pyplot as plt
 
 def wing():


### PR DESCRIPTION
This PR removes `g` as a class and lifts all of its variables into global variables. Usage in modules that use `g` does not change, as we can simply use `import globals as g`. This is also useful for Numba JIT compiling down the line, as when cached, Numba optimizes global variables into constants. Unless there was a specific rationale for using the class, I also think this is much cleaner in general.